### PR TITLE
Backend/jong/kakao api #50

### DIFF
--- a/backend/src/main/java/com/magicdev/manalgak/common/cache/CacheKeys.java
+++ b/backend/src/main/java/com/magicdev/manalgak/common/cache/CacheKeys.java
@@ -29,6 +29,20 @@ public class CacheKeys {
     }
 
     /**
+     * 중간지점 기반 장소 목록 캐시 키 생성
+     * 형식: places:meeting:{meetingUuid}:midpoint:{purpose}:{limit}
+     *
+     * @param meetingUuid 모임 UUID
+     * @param purpose     모임 목적 (DINING, CAFE, CULTURE, TOUR)
+     * @param limit       반환할 장소 수
+     * @return 캐시 키 (예: places:meeting:abc-123:midpoint:DINING:10)
+     */
+    public static String placesKeyByMidpoint(String meetingUuid, String purpose, int limit) {
+        return String.format("places:meeting:%s:midpoint:%s:%d",
+                meetingUuid, purpose, limit);
+    }
+
+    /**
      * 특정 후보지의 모든 장소 캐시 패턴
      * 형식: *:candidate:{candidateId}:*
      *

--- a/backend/src/main/java/com/magicdev/manalgak/domain/external/kakao/dto/KakaoPlaceSearchResponse.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/external/kakao/dto/KakaoPlaceSearchResponse.java
@@ -1,4 +1,61 @@
 package com.magicdev.manalgak.domain.external.kakao.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
 public class KakaoPlaceSearchResponse {
+    private Meta meta;
+    private List<Document> documents;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Meta {
+        @JsonProperty("total_count")
+        private Integer totalCount;
+
+        @JsonProperty("pageable_count")
+        private Integer pageableCount;
+
+        @JsonProperty("is_end")
+        private Boolean isEnd;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Document {
+        private String id;
+
+        @JsonProperty("place_name")
+        private String placeName;
+
+        @JsonProperty("category_name")
+        private String categoryName;
+
+        @JsonProperty("category_group_code")
+        private String categoryGroupCode;
+
+        @JsonProperty("category_group_name")
+        private String categoryGroupName;
+
+        private String phone;
+
+        @JsonProperty("address_name")
+        private String addressName;
+
+        @JsonProperty("road_address_name")
+        private String roadAddressName;
+
+        private String x;  // 경도 (longitude)
+        private String y;  // 위도 (latitude)
+
+        @JsonProperty("place_url")
+        private String placeUrl;
+
+        private String distance;
+    }
 }

--- a/backend/src/main/java/com/magicdev/manalgak/domain/external/kakao/service/KakaoLocalApiService.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/external/kakao/service/KakaoLocalApiService.java
@@ -1,4 +1,75 @@
 package com.magicdev.manalgak.domain.external.kakao.service;
 
+import com.magicdev.manalgak.domain.external.kakao.dto.KakaoPlaceSearchResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class KakaoLocalApiService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${api.kakao.key}")
+    private String kakaoApiKey;
+
+    private static final String KAKAO_CATEGORY_API_URL =
+            "https://dapi.kakao.com/v2/local/search/category.json";
+
+    /**
+     * 카테고리로 장소 검색
+     * @param categoryCode 카테고리 코드 (FD6, CE7, CT1, AT4)
+     * @param longitude 경도 (x)
+     * @param latitude 위도 (y)
+     * @param radius 반경 (m)
+     * @param size 결과 개수
+     */
+    public KakaoPlaceSearchResponse searchByCategory(
+            String categoryCode,
+            Double longitude,
+            Double latitude,
+            Integer radius,
+            Integer size
+    ) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(KAKAO_CATEGORY_API_URL)
+                .queryParam("category_group_code", categoryCode)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", radius)
+                .queryParam("sort", "accuracy")
+                .queryParam("size", size);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoPlaceSearchResponse> response =
+                    restTemplate.exchange(
+                            builder.toUriString(),
+                            HttpMethod.GET,
+                            entity,
+                            KakaoPlaceSearchResponse.class
+                    );
+
+            log.info("카카오 API 호출 성공: {}개 결과",
+                    response.getBody().getDocuments().size());
+
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("카카오 API 호출 실패: {}", e.getMessage());
+            throw new RuntimeException("카카오 API 호출 실패", e);
+        }
+    }
 }

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/controller/MeetingPlaceController.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/controller/MeetingPlaceController.java
@@ -1,0 +1,62 @@
+package com.magicdev.manalgak.domain.place.controller;
+
+import com.magicdev.manalgak.common.dto.CommonResponse;
+import com.magicdev.manalgak.domain.place.dto.PlaceResponse;
+import com.magicdev.manalgak.domain.place.dto.PlaceSelectRequest;
+import com.magicdev.manalgak.domain.place.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/meetings/{meetingUuid}")
+@RequiredArgsConstructor
+@Tag(name = "Meeting Places", description = "모임 장소 추천 및 선택 API")
+public class MeetingPlaceController {
+
+    private final PlaceService placeService;
+
+    @GetMapping("/places")
+    @Operation(
+            summary = "추천 장소 조회",
+            description = "중간지점 기반으로 카카오 장소 검색 API를 호출하여 추천 장소를 조회합니다."
+    )
+    public ResponseEntity<CommonResponse<PlaceResponse>> getRecommendedPlaces(
+            @PathVariable String meetingUuid,
+            @Parameter(description = "목적: DINING, CAFE, CULTURE, TOUR")
+            @RequestParam(defaultValue = "DINING") String purpose,
+            @Parameter(description = "검색 개수")
+            @RequestParam(defaultValue = "15") int limit
+    ) {
+        PlaceResponse response = placeService.getRecommendedPlaces(meetingUuid, purpose, limit);
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    @PostMapping("/place/select")
+    @Operation(
+            summary = "장소 선택 저장",
+            description = "사용자가 선택한 장소를 DB에 저장합니다."
+    )
+    public ResponseEntity<CommonResponse<PlaceResponse.Place>> selectPlace(
+            @PathVariable String meetingUuid,
+            @RequestBody PlaceSelectRequest request
+    ) {
+        PlaceResponse.Place selectedPlace = placeService.saveSelectedPlace(meetingUuid, request);
+        return ResponseEntity.ok(CommonResponse.success(selectedPlace));
+    }
+
+    @GetMapping("/place")
+    @Operation(
+            summary = "선택된 장소 조회",
+            description = "모임에서 선택된 장소를 조회합니다."
+    )
+    public ResponseEntity<CommonResponse<PlaceResponse.Place>> getSelectedPlace(
+            @PathVariable String meetingUuid
+    ) {
+        PlaceResponse.Place selectedPlace = placeService.getSelectedPlace(meetingUuid);
+        return ResponseEntity.ok(CommonResponse.success(selectedPlace));
+    }
+}

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/dto/PlaceResponse.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/dto/PlaceResponse.java
@@ -1,5 +1,6 @@
 package com.magicdev.manalgak.domain.place.dto;
 
+import com.magicdev.manalgak.domain.algorithm.Model.Coordinate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,8 @@ import java.util.List;
 @AllArgsConstructor
 public class PlaceResponse {
     private List<Place> places;
-    private int totalCount;
+    private Integer totalCount;
+    private Coordinate midpoint;
     private boolean fromCache;
 
     @Data
@@ -21,12 +23,34 @@ public class PlaceResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Place {
+        private String placeId;
         private String placeName;
+
+        // 프론트엔드 카테고리 (cafe, restaurant, culture, tour)
+        private String category;
+
+        // 카카오 API 원본 카테고리
+        private String categoryGroupCode;
+        private String categoryGroupName;
         private String categoryName;
+
+        // 주소
         private String address;
+        private String roadAddress;
+
+        // 좌표
         private Double latitude;
         private Double longitude;
+
+        // 거리 및 도보 시간
         private Integer distance;
-        private Double rating;
+        private Integer walkingMinutes;
+
+        // 기준 위치명
+        private String stationName;
+
+        // 기타 정보
+        private String phone;
+        private String placeUrl;
     }
 }

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/dto/PlaceSelectRequest.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/dto/PlaceSelectRequest.java
@@ -1,0 +1,26 @@
+package com.magicdev.manalgak.domain.place.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceSelectRequest {
+    private String placeId;
+    private String placeName;
+    private String category;
+    private String categoryGroupCode;
+    private String categoryGroupName;
+    private String address;
+    private String roadAddress;
+    private Double latitude;
+    private Double longitude;
+    private Integer distance;
+    private Integer walkingMinutes;
+    private String phone;
+    private String placeUrl;
+}

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/entity/RecommendedPlace.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/entity/RecommendedPlace.java
@@ -1,4 +1,63 @@
 package com.magicdev.manalgak.domain.place.entity;
 
+import com.magicdev.manalgak.domain.meeting.entity.Meeting;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recommended_places")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class RecommendedPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @Column(nullable = false)
+    private String placeId;  // 카카오 장소 ID
+
+    @Column(nullable = false)
+    private String placeName;
+
+    private String category;
+
+    private String categoryGroupCode;
+
+    private String categoryGroupName;
+
+    private String address;
+
+    private String roadAddress;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private Integer distance;
+
+    private Integer walkingMinutes;
+
+    private String phone;
+
+    private String placeUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/repository/RecommendedPlaceRepository.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/repository/RecommendedPlaceRepository.java
@@ -1,4 +1,17 @@
 package com.magicdev.manalgak.domain.place.repository;
 
-public interface RecommendedPlaceRepository {
+import com.magicdev.manalgak.domain.place.entity.RecommendedPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RecommendedPlaceRepository extends JpaRepository<RecommendedPlace, Long> {
+
+    Optional<RecommendedPlace> findByMeetingMeetingUuid(String meetingUuid);
+
+    boolean existsByMeetingMeetingUuid(String meetingUuid);
+
+    void deleteByMeetingMeetingUuid(String meetingUuid);
 }

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/service/PlaceService.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/service/PlaceService.java
@@ -2,15 +2,26 @@ package com.magicdev.manalgak.domain.place.service;
 
 import com.magicdev.manalgak.common.cache.CacheKeys;
 import com.magicdev.manalgak.common.cache.CacheTTL;
+import com.magicdev.manalgak.common.exception.BusinessException;
+import com.magicdev.manalgak.common.exception.ErrorCode;
+import com.magicdev.manalgak.domain.algorithm.Model.Coordinate;
+import com.magicdev.manalgak.domain.algorithm.service.MidpointCalculationService;
+import com.magicdev.manalgak.domain.external.kakao.dto.KakaoPlaceSearchResponse;
+import com.magicdev.manalgak.domain.external.kakao.service.KakaoLocalApiService;
+import com.magicdev.manalgak.domain.meeting.entity.Meeting;
+import com.magicdev.manalgak.domain.meeting.repository.MeetingRepository;
 import com.magicdev.manalgak.domain.place.dto.PlaceResponse;
+import com.magicdev.manalgak.domain.place.dto.PlaceSelectRequest;
+import com.magicdev.manalgak.domain.place.entity.RecommendedPlace;
+import com.magicdev.manalgak.domain.place.repository.RecommendedPlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -18,9 +29,15 @@ import java.util.stream.IntStream;
 public class PlaceService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final KakaoLocalApiService kakaoLocalApiService;
+    private final MidpointCalculationService midpointCalculationService;
+    private final RecommendedPlaceRepository recommendedPlaceRepository;
+    private final MeetingRepository meetingRepository;
 
-    public PlaceResponse getRecommendedPlaces(String meetingUuid, Long candidateId, String purpose, int limit) {
-        String cacheKey = CacheKeys.placesKey(meetingUuid, candidateId, purpose, limit);
+    private static final int DEFAULT_RADIUS = 500;  // 반경 500m
+
+    public PlaceResponse getRecommendedPlaces(String meetingUuid, String purpose, int limit) {
+        String cacheKey = CacheKeys.placesKeyByMidpoint(meetingUuid, purpose, limit);
 
         PlaceResponse cached = getCachedPlaces(cacheKey);
         if (cached != null) {
@@ -30,12 +47,17 @@ public class PlaceService {
         }
 
         log.info("Cache MISS: {}, calling Kakao API", cacheKey);
-        PlaceResponse response = callKakaoApi(candidateId, purpose, limit);
+        PlaceResponse response = callKakaoApi(meetingUuid, purpose, limit);
         response.setFromCache(false);
 
         savePlacesToCache(cacheKey, response);
 
         return response;
+    }
+
+    // 기존 메서드 유지 (하위 호환성)
+    public PlaceResponse getRecommendedPlaces(String meetingUuid, Long candidateId, String purpose, int limit) {
+        return getRecommendedPlaces(meetingUuid, purpose, limit);
     }
 
     private PlaceResponse getCachedPlaces(String cacheKey) {
@@ -48,13 +70,83 @@ public class PlaceService {
         }
     }
 
-    private PlaceResponse callKakaoApi(Long candidateId, String purpose, int limit) {
-        List<PlaceResponse.Place> places = generateDummyPlaces(purpose, limit);
+    private PlaceResponse callKakaoApi(String meetingUuid, String purpose, int limit) {
+        // 1. 중간지점 계산
+        Coordinate midpoint = midpointCalculationService.returnMidPointByMeetingID(meetingUuid);
+
+        log.info("중간지점 계산 완료: lat={}, lng={}",
+                midpoint.getLatitude(), midpoint.getLongitude());
+
+        // 2. 목적 -> 카카오 카테고리 코드 변환
+        String categoryCode = mapPurposeToKakaoCode(purpose);
+
+        // 3. 목적 -> 프론트엔드 카테고리 변환
+        String frontCategory = mapPurposeToFrontCategory(purpose);
+
+        // 4. 카카오 API 호출
+        KakaoPlaceSearchResponse kakaoResponse = kakaoLocalApiService.searchByCategory(
+                categoryCode,
+                midpoint.getLongitude(),  // x
+                midpoint.getLatitude(),   // y
+                DEFAULT_RADIUS,
+                limit
+        );
+
+        // 5. 응답 변환
+        List<PlaceResponse.Place> places = kakaoResponse.getDocuments()
+                .stream()
+                .map(doc -> convertToPlace(doc, frontCategory))
+                .collect(Collectors.toList());
 
         return PlaceResponse.builder()
                 .places(places)
-                .totalCount(places.size())
+                .totalCount(kakaoResponse.getMeta().getTotalCount())
+                .midpoint(midpoint)
+                .fromCache(false)
                 .build();
+    }
+
+    /**
+     * 카카오 응답 -> PlaceResponse.Place 변환
+     */
+    private PlaceResponse.Place convertToPlace(
+            KakaoPlaceSearchResponse.Document doc,
+            String frontCategory
+    ) {
+        int distance = 0;
+        try {
+            distance = Integer.parseInt(doc.getDistance());
+        } catch (NumberFormatException e) {
+            log.warn("거리 파싱 실패: {}", doc.getDistance());
+        }
+
+        int walkingMinutes = (int) Math.ceil(distance / 80.0);  // 도보 시간 계산 (80m/분)
+
+        return PlaceResponse.Place.builder()
+                .placeId(doc.getId())
+                .placeName(doc.getPlaceName())
+                .category(frontCategory)
+                .categoryGroupCode(doc.getCategoryGroupCode())
+                .categoryGroupName(doc.getCategoryGroupName())
+                .categoryName(doc.getCategoryName())
+                .address(doc.getAddressName())
+                .roadAddress(doc.getRoadAddressName())
+                .latitude(parseDouble(doc.getY()))
+                .longitude(parseDouble(doc.getX()))
+                .distance(distance)
+                .walkingMinutes(walkingMinutes)
+                .stationName("중간지점")
+                .phone(doc.getPhone())
+                .placeUrl(doc.getPlaceUrl())
+                .build();
+    }
+
+    private Double parseDouble(String value) {
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
     }
 
     private void savePlacesToCache(String cacheKey, PlaceResponse response) {
@@ -70,29 +162,112 @@ public class PlaceService {
         }
     }
 
-    private List<PlaceResponse.Place> generateDummyPlaces(String purpose, int limit) {
-        String category = getCategory(purpose);
-
-        return IntStream.range(0, limit)
-                .mapToObj(i -> PlaceResponse.Place.builder()
-                        .placeName(String.format("%s 장소 %d", category, i + 1))
-                        .categoryName(category)
-                        .address(String.format("서울시 마포구 합정동 %d로 %d", 100 + i, i + 1))
-                        .latitude(37.5547 + (i * 0.001))
-                        .longitude(126.9707 + (i * 0.001))
-                        .distance(300 + i * 100)
-                        .rating(4.0 + (i * 0.2))
-                        .build())
-                .collect(Collectors.toList());
+    /**
+     * 목적 -> 카카오 카테고리 코드 매핑
+     */
+    private String mapPurposeToKakaoCode(String purpose) {
+        if (purpose == null) {
+            return "FD6";
+        }
+        return switch (purpose.toUpperCase()) {
+            case "DINING", "RESTAURANT", "BRUNCH", "DRINK" -> "FD6";  // 음식점
+            case "CAFE", "DATE", "STUDY" -> "CE7";                     // 카페
+            case "CULTURE", "MOVIE", "KARAOKE" -> "CT1";               // 문화시설
+            case "TOUR", "SHOPPING" -> "AT4";                          // 관광명소
+            default -> "FD6";
+        };
     }
 
-    private String getCategory(String purpose) {
-        if ("DINING".equals(purpose)) {
-            return "식당";
-        } else if ("CAFE".equals(purpose)) {
-            return "카페";
-        } else {
-            return "기타";
+    /**
+     * 목적 -> 프론트엔드 카테고리 매핑
+     */
+    private String mapPurposeToFrontCategory(String purpose) {
+        if (purpose == null) {
+            return "restaurant";
         }
+        return switch (purpose.toUpperCase()) {
+            case "DINING", "RESTAURANT", "BRUNCH", "DRINK" -> "restaurant";
+            case "CAFE", "DATE", "STUDY" -> "cafe";
+            case "CULTURE", "MOVIE", "KARAOKE" -> "culture";
+            case "TOUR", "SHOPPING" -> "tour";
+            default -> "restaurant";
+        };
+    }
+
+    // ========== 선택 장소 저장/조회 기능 ==========
+
+    /**
+     * 선택한 장소 저장
+     */
+    @Transactional
+    public PlaceResponse.Place saveSelectedPlace(String meetingUuid, PlaceSelectRequest request) {
+        Meeting meeting = meetingRepository.findByMeetingUuid(meetingUuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        // 기존 선택 장소가 있으면 삭제 (1개의 모임에 1개의 선택 장소만 허용)
+        if (recommendedPlaceRepository.existsByMeetingMeetingUuid(meetingUuid)) {
+            recommendedPlaceRepository.deleteByMeetingMeetingUuid(meetingUuid);
+        }
+
+        RecommendedPlace recommendedPlace = RecommendedPlace.builder()
+                .meeting(meeting)
+                .placeId(request.getPlaceId())
+                .placeName(request.getPlaceName())
+                .category(request.getCategory())
+                .categoryGroupCode(request.getCategoryGroupCode())
+                .categoryGroupName(request.getCategoryGroupName())
+                .address(request.getAddress())
+                .roadAddress(request.getRoadAddress())
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .distance(request.getDistance())
+                .walkingMinutes(request.getWalkingMinutes())
+                .phone(request.getPhone())
+                .placeUrl(request.getPlaceUrl())
+                .build();
+
+        RecommendedPlace saved = recommendedPlaceRepository.save(recommendedPlace);
+
+        log.info("선택 장소 저장 완료: meetingUuid={}, placeId={}", meetingUuid, saved.getPlaceId());
+
+        return convertToPlaceDto(saved);
+    }
+
+    /**
+     * 선택된 장소 조회
+     */
+    @Transactional(readOnly = true)
+    public PlaceResponse.Place getSelectedPlace(String meetingUuid) {
+        RecommendedPlace recommendedPlace = recommendedPlaceRepository
+                .findByMeetingMeetingUuid(meetingUuid)
+                .orElse(null);
+
+        if (recommendedPlace == null) {
+            return null;
+        }
+
+        return convertToPlaceDto(recommendedPlace);
+    }
+
+    /**
+     * RecommendedPlace 엔티티 -> PlaceResponse.Place DTO 변환
+     */
+    private PlaceResponse.Place convertToPlaceDto(RecommendedPlace entity) {
+        return PlaceResponse.Place.builder()
+                .placeId(entity.getPlaceId())
+                .placeName(entity.getPlaceName())
+                .category(entity.getCategory())
+                .categoryGroupCode(entity.getCategoryGroupCode())
+                .categoryGroupName(entity.getCategoryGroupName())
+                .address(entity.getAddress())
+                .roadAddress(entity.getRoadAddress())
+                .latitude(entity.getLatitude())
+                .longitude(entity.getLongitude())
+                .distance(entity.getDistance())
+                .walkingMinutes(entity.getWalkingMinutes())
+                .stationName("중간지점")
+                .phone(entity.getPhone())
+                .placeUrl(entity.getPlaceUrl())
+                .build();
     }
 }

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/service/PlaceService.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/service/PlaceService.java
@@ -92,10 +92,11 @@ public class PlaceService {
                 limit
         );
 
-        // 5. 응답 변환
+        // 5. 응답 변환 (좌표가 null인 장소는 제외)
         List<PlaceResponse.Place> places = kakaoResponse.getDocuments()
                 .stream()
                 .map(doc -> convertToPlace(doc, frontCategory))
+                .filter(place -> place.getLatitude() != null && place.getLongitude() != null)
                 .collect(Collectors.toList());
 
         return PlaceResponse.builder()
@@ -142,10 +143,15 @@ public class PlaceService {
     }
 
     private Double parseDouble(String value) {
+        if (value == null || value.isBlank()) {
+            log.error("좌표 값이 비어있습니다: '{}'", value);
+            return null;
+        }
         try {
             return Double.parseDouble(value);
         } catch (NumberFormatException e) {
-            return 0.0;
+            log.error("좌표 파싱 실패 - 유효하지 않은 값: '{}'", value);
+            return null;
         }
     }
 

--- a/backend/src/main/resources/db/migration/V4__create_recommended_places.sql
+++ b/backend/src/main/resources/db/migration/V4__create_recommended_places.sql
@@ -1,0 +1,25 @@
+-- V4: 추천 장소 테이블 생성
+
+CREATE TABLE IF NOT EXISTS recommended_places (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    meeting_id BIGINT NOT NULL,
+    place_id VARCHAR(100) NOT NULL,
+    place_name VARCHAR(200) NOT NULL,
+    category VARCHAR(50),
+    category_group_code VARCHAR(20),
+    category_group_name VARCHAR(100),
+    address VARCHAR(500),
+    road_address VARCHAR(500),
+    latitude DOUBLE,
+    longitude DOUBLE,
+    distance INT,
+    walking_minutes INT,
+    phone VARCHAR(50),
+    place_url VARCHAR(500),
+    created_at DATETIME,
+    INDEX idx_meeting_id (meeting_id),
+    INDEX idx_place_id (place_id),
+    CONSTRAINT fk_recommended_places_meeting
+        FOREIGN KEY (meeting_id) REFERENCES meetings(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## 변경 사항                                                                                                                                                                  
  중간지점 기반 카카오 로컬 API 연동하여 추천 장소 조회/선택/저장 기능 구현                                                                                                     
                                                                                                                                                                                
  ## 관련 이슈                                                                                                                                                                  
  Ref #50                                                                                                                                                                       
                                                                                                                                                                                
  ## 테스트                                                                                                                                                                     
  - [x] 로컬에서 테스트 완료                                                                                                                                                    
  - [ ] 빌드 확인                                                                                                                                                               
                                                                                                                                                                                
  ### 테스트 결과                                                                                                                                                               
  - `GET /api/v1/meetings/{uuid}/places?purpose=DINING` → 음식점 추천 정상                                                                                                      
  - `GET /api/v1/meetings/{uuid}/places?purpose=CAFE` → 카페 추천 정상                                                                                                          
  - `POST /api/v1/meetings/{uuid}/place/select` → 장소 선택 저장 정상                                                                                                           
  - `GET /api/v1/meetings/{uuid}/place` → 선택 장소 조회 정상                                                                                                                   
                                                                                                                                                                                
  ### 팀원 참고                                                                                                                                                                 
  - `recommended_places` 테이블 수동 생성 필요 (Flyway 비활성화 상태)                                                                                                           
    - `src/main/resources/db/migration/V4__create_recommended_places.sql` 실행                                                                                                  
  - Redis 실행 필요 (캐싱용)                                                                                                                                                    
  - `.env`에 `KAKAO_API_KEY` 설정 필요