### PR TITLE
Backend/haeun/update1

### DIFF
--- a/backend/src/main/java/com/magicdev/manalgak/ManalGakApplication.java
+++ b/backend/src/main/java/com/magicdev/manalgak/ManalGakApplication.java
@@ -1,12 +1,20 @@
 package com.magicdev.manalgak;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class ManalGakApplication {
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(ManalGakApplication.class, args);

--- a/backend/src/main/java/com/magicdev/manalgak/domain/meeting/dto/MeetingCreateRequest.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/meeting/dto/MeetingCreateRequest.java
@@ -12,12 +12,14 @@ public class MeetingCreateRequest {
 
     private String meetingName;
     private LocalDateTime meetingTime;
+    private LocalDateTime endTime;
     private Meeting.MeetingPurpose purpose;
 
     public CreateMeetingCommand toCommand(Long organizerId) {
         return CreateMeetingCommand.builder()
                 .meetingName(this.meetingName)
                 .meetingTime(this.meetingTime)
+                .endTime(this.endTime)
                 .purpose(this.purpose)
                 .organizerId(organizerId)
                 .build();

--- a/backend/src/main/java/com/magicdev/manalgak/domain/meeting/dto/MeetingCreateResponse.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/meeting/dto/MeetingCreateResponse.java
@@ -14,6 +14,7 @@ public class MeetingCreateResponse {
     private String meetingUuid;
     private String meetingName;
     private LocalDateTime meetingTime;
+    private LocalDateTime endTime;
     private String status;
     private String shareUrl;
     private LocalDateTime expiresAt;
@@ -25,6 +26,7 @@ public class MeetingCreateResponse {
                 .meetingUuid(meeting.getMeetingUuid())
                 .meetingName(meeting.getMeetingName())
                 .meetingTime(meeting.getMeetingTime())
+                .endTime(meeting.getEndTime())
                 .status(meeting.getStatus().name())
                 .shareUrl(shareUrl)
                 .expiresAt(meeting.getExpiresAt())

--- a/backend/src/main/java/com/magicdev/manalgak/domain/meeting/dto/MeetingDetailResponse.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/meeting/dto/MeetingDetailResponse.java
@@ -29,7 +29,7 @@ public class MeetingDetailResponse {
                 .endTime(meeting.getEndTime())
                 .purpose(meeting.getPurpose())
                 .status(meeting.getStatus())
-                .totalParticipants(meeting.getTotalParticipants())
+                .totalParticipants(participants.size())
                 .participants(participants)
                 .organizerId(meeting.getOrganizerId())
                 .meetingUuid(meeting.getMeetingUuid())

--- a/backend/src/main/java/com/magicdev/manalgak/domain/meeting/service/command/CreateMeetingCommand.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/meeting/service/command/CreateMeetingCommand.java
@@ -12,6 +12,7 @@ public class CreateMeetingCommand {
     private Long organizerId;
     private String meetingName;
     private LocalDateTime meetingTime;
+    private LocalDateTime endTime;
     private Meeting.MeetingPurpose purpose;
 
     public Meeting toEntity() {
@@ -20,6 +21,7 @@ public class CreateMeetingCommand {
         meeting.setMeetingName(this.meetingName);
         meeting.setMeetingTime(this.meetingTime);
         meeting.setPurpose(this.purpose);
+        meeting.setEndTime(this.endTime);
         return meeting;
     }
 }

--- a/frontend/src/app/meetings/new/step1-basic/page.tsx
+++ b/frontend/src/app/meetings/new/step1-basic/page.tsx
@@ -5,24 +5,43 @@ import { useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import StepNavigation from "@/components/layout/StepNavigation";
 import Step1Form, { Step1FormRef } from "@/components/meeting/Step1/Step1Form";
-
+import { useUser } from "@/context/UserContext";
+import LoginRequired from "@/components/common/LoginRequired";
 // useSearchParams를 사용하는 컴포넌트를 분리
 function Step1Content() {
+  const { user, loading } = useUser();
   const formRef = useRef<Step1FormRef>(null);
   const searchParams = useSearchParams();
+  const readonly = searchParams.get("readonly") === "true";
+
   const meetingUuid = searchParams.get("meetingUuid") || undefined;
 
+    // ✅ 로딩 중일 때
+    if (loading) {
+      return (
+        <div className="flex items-center justify-center py-20">
+          <div className="text-sm text-gray-500">로딩 중...</div>
+        </div>
+      )
+}
+  if (!user) {
+    return <LoginRequired />;
+  }
+
   const handleNext = async () => {
-    if (!formRef.current) {
-      throw new Error("Form ref not found");
+    if (readonly) {
+      // 참여자: 수정 API 호출 X
+      return `/meetings/new/step2-meetingmembers?meetingUuid=${meetingUuid}&readonly=true`;
     }
+
+    // 모임장: 기존 로직 그대로
+    if (!formRef.current) throw new Error("Form ref not found");
 
     if (!formRef.current.isValid()) {
       alert("모든 필수 정보를 입력해주세요.");
       throw new Error("Validation failed");
     }
 
-    // 생성 OR 수정 (meetingUuid 유무에 따라 자동 판단)
     const resultMeetingUuid = await formRef.current.createOrUpdateMeeting();
 
     if (!resultMeetingUuid) {
@@ -37,7 +56,7 @@ function Step1Content() {
       <main className="space-y-6 pb-24">
         <div className="space-y-2">
           <h1 className="text-2xl font-semibold">
-            Step 1. 기본 정보 {meetingUuid && <span className="text-sm text-gray-500">(수정)</span>}
+            Step 1. 기본 정보
           </h1>
           <p className="text-sm text-[var(--wf-subtle)]">
             모임의 기본 정보와 목적, 일정을 한 번에 설정해 주세요. 선택한 정보에
@@ -45,7 +64,7 @@ function Step1Content() {
           </p>
         </div>
 
-        <Step1Form ref={formRef} meetingUuid={meetingUuid} />
+        <Step1Form ref={formRef} meetingUuid={meetingUuid} readonly={readonly} />
       </main>
 
       <StepNavigation

--- a/frontend/src/app/meetings/none/page.tsx
+++ b/frontend/src/app/meetings/none/page.tsx
@@ -1,0 +1,28 @@
+'use client'; // 반드시 붙이기
+
+import { useRouter } from 'next/navigation';
+import Button from '@/components/ui/Button';
+
+export default function MeetingCompleteFallbackPage() {
+  const router = useRouter();
+
+  return (
+    <main className="flex flex-col items-center justify-center min-h-[60vh] p-6">
+      <div className="max-w-md w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-md p-8 text-center">
+        <h1 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">
+          👋 아직 모임이 없어요
+        </h1>
+        <p className="text-gray-700 dark:text-gray-300 mb-6">
+          먼저 Step1에서 모임을 생성해야 <br />
+          서비스를 이용할 수 있습니다.
+        </p>
+        <Button
+          onClick={() => router.push('/meetings/new/step1-basic')}
+          className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-500 transition-colors"
+        >
+          Step1로 이동
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/common/LoginRequired.tsx
+++ b/frontend/src/components/common/LoginRequired.tsx
@@ -1,0 +1,25 @@
+// src/components/common/LoginRequired.tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function LoginRequired() {
+  const router = useRouter();
+
+  return (
+    <main className="flex flex-col items-center justify-center min-h-[60vh] p-6">
+      <div className="max-w-md w-full bg-white border rounded-2xl shadow-md p-8 text-center">
+        <h1 className="text-2xl font-bold mb-4">🔒 로그인이 필요해요</h1>
+        <p className="text-gray-600 mb-6">
+          서비스를 이용하기 위해 먼저 로그인해야 합니다.
+        </p>
+        <button
+          onClick={() => router.push("/")}
+          className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-500"
+        >
+          로그인하러 가기
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/layout/BottomTabNavigation.tsx
+++ b/frontend/src/components/layout/BottomTabNavigation.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import BottomCTA from '@/components/layout/BottomCTA'
 import {
   Home,
@@ -11,57 +11,90 @@ import {
 } from 'lucide-react'
 import clsx from 'clsx'
 
-const TABS = [
-  { label: '메인', href: '/', icon: Home },
-  { label: '모임생성', href: '/meetings/new', icon: PlusCircle },
-  { label: '참여자설정', href: '/meetings/new/step2-meetingmembers', icon: Users },
-  { label: '추천장소', href: '/meetings/new/step3-result', icon: MapPin },
-  { label: '확정내용', href: '/meetings/meeting-001/complete', icon: CheckCircle,},
-]
-
 export default function BottomTabNavigation() {
   const router = useRouter()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // ✅ meetingUuid 추출 (query → path fallback)
+  let meetingUuid = searchParams.get('meetingUuid')
+
+  if (!meetingUuid) {
+    const match = pathname.match(/\/meetings\/([^/]+)\/complete/)
+    meetingUuid = match?.[1] ?? null
+  }
+
+  const TABS = [
+    { label: '메인', href: '/', icon: Home },
+
+    {
+      label: '모임생성',
+      href: meetingUuid
+        ? `/meetings/new/step1-basic?meetingUuid=${meetingUuid}`
+        : `/meetings/new/step1-basic`,
+      icon: PlusCircle,
+    },
+
+    {
+      label: '참여자설정',
+      href: meetingUuid
+        ? `/meetings/new/step2-meetingmembers?meetingUuid=${meetingUuid}`
+        : `/meetings/new/step2-meetingmembers`,
+      icon: Users,
+    },
+
+    {
+      label: '추천장소',
+      href: meetingUuid
+        ? `/meetings/new/step3-result?meetingUuid=${meetingUuid}`
+        : `/meetings/new/step3-result`,
+      icon: MapPin,
+    },
+
+    {
+      label: '확정내용',
+      href: meetingUuid
+        ? `/meetings/${meetingUuid}/complete`
+        : `/meetings/complete`,
+      icon: CheckCircle,
+    },
+  ]
 
   return (
     <BottomCTA>
       <nav className="flex w-full items-center justify-between bg-[var(--wf-bg-soft)] border-t border-[var(--wf-border)]">
         {TABS.map(({ label, href, icon: Icon }) => {
-          const isActive = pathname.startsWith(href)
+          const isActive = pathname.startsWith(href.split('?')[0])
 
           return (
             <button
-              key={href}
+              key={label}
               type="button"
               onClick={() => router.push(href)}
               className="group flex flex-1 flex-col items-center justify-center gap-1 py-2"
             >
-              {/* 아이콘 영역 */}
               <div
                 className={clsx(
-                  'flex h-10 w-10 items-center justify-center rounded-full transition-colors  hover:bg-[var(--wf-highlight)]',
-                  isActive
-                    ? 'bg-[var(--wf-highlight)]'
-                    : 'bg-transparent'
+                  'flex h-10 w-10 items-center justify-center rounded-full',
+                  isActive && 'bg-[var(--wf-highlight)]'
                 )}
               >
                 <Icon
                   className={clsx(
-                    'h-5 w-5 transition-colors',
+                    'h-5 w-5',
                     isActive
                       ? 'text-[var(--wf-accent)]'
-                      : 'text-[var(--wf-subtle)] group-hover:text-[var(--wf-accent)]'
+                      : 'text-[var(--wf-subtle)]'
                   )}
                 />
               </div>
 
-              {/* 라벨 */}
               <span
                 className={clsx(
-                  'text-xs transition-colors',
+                  'text-xs',
                   isActive
                     ? 'font-semibold text-[var(--wf-text)]'
-                    : 'font-normal text-[var(--wf-subtle)] group-hover:text-[var(--wf-text)]'
+                    : 'text-[var(--wf-subtle)]'
                 )}
               >
                 {label}

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import axios from 'axios'
 
 export interface User {
   id: number
@@ -9,35 +10,53 @@ export interface User {
 
 interface UserContextType {
   user: User | null
+  loading: boolean
   setUser: (user: User | null) => void
 }
 
 const UserContext = createContext<UserContextType>({
   user: null,
+  loading: true,
   setUser: () => {},
 })
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUserState] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
 
+  // ✅ 앱 시작 시 "진짜 로그인 상태" 확인
   useEffect(() => {
-    const stored = localStorage.getItem('user')
-    if (stored) setUserState(JSON.parse(stored))
+    const fetchMe = async () => {
+      try {
+        const res = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/me`,
+          { withCredentials: true }
+        )
+
+        const userData = {
+          id: res.data.data.userId,
+          name: res.data.data.nickname,
+          profileImage: res.data.data.profileImageUrl,
+        }
+
+        setUserState(userData)
+      } catch  {
+        // ❌ 토큰 없거나 만료 → 비로그인
+        setUserState(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchMe()
   }, [])
 
-  // ✅ null도 받을 수 있게 수정
   const setUser = (user: User | null) => {
-    if (user === null) {
-      localStorage.removeItem('user')
-      setUserState(null)
-    } else {
-      localStorage.setItem('user', JSON.stringify(user))
-      setUserState(user)
-    }
+    setUserState(user)
   }
 
   return (
-    <UserContext.Provider value={{ user, setUser }}>
+    <UserContext.Provider value={{ user, loading, setUser }}>
       {children}
     </UserContext.Provider>
   )


### PR DESCRIPTION
## 변경 사항
<!-- 뭐 했는지 한 줄 설명 -->
모임 생성 시 종료시간 입력 받고 조회되도록,
햄버거 메뉴 각 링크 uuid 있으면 전달되도록, 없으면 기본페이지(스텝1로 유도 메세지 추가)
하단 BottomTabNavigation도 동일하게 수정,
로그인한 상태아니면 모임 생성 페이지 이동 시 로그인 유도 
모임 리스트 조회 시 참여자 count 수정 
모임 삭제 api 연결,
햄버거 유저정보와 홈의 로그인 유무 싱크 일치,
참여링크 uuid 전달,
시간 DB와 프론트 일치되도록 수정
모임 리스트 모임장만 수정, 나머지 조회되도록
모임장이 아닐시 스텝1 readonly
확정된 모임일 경우 스텝2 업데이트 안하도록
참여 멤버 초대 메세지 모임장만 가능하도록 

## 관련 이슈
<!-- 사용 예시(closes #123, #124, #125) -->
closes #


## 테스트
- [ ] 로컬에서 테스트 완료
- [ ] 빌드 확인


<!-- 스크린샷이나 추가 설명 필요하면 여기에 -->
