### PR TITLE
feat: 추천 장소 하이브리드 캐싱 구현 (Redis + DB) #50

### DIFF
--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/entity/PlaceCandidate.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/entity/PlaceCandidate.java
@@ -1,0 +1,65 @@
+package com.magicdev.manalgak.domain.place.entity;
+
+import com.magicdev.manalgak.domain.meeting.entity.Meeting;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "place_candidates")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlaceCandidate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @Column(nullable = false)
+    private String placeId;
+
+    @Column(nullable = false)
+    private String placeName;
+
+    private String category;
+
+    private String categoryGroupCode;
+
+    private String categoryGroupName;
+
+    private String categoryName;
+
+    private String address;
+
+    private String roadAddress;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private Integer distance;
+
+    private Integer walkingMinutes;
+
+    private String phone;
+
+    private String placeUrl;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/magicdev/manalgak/domain/place/repository/PlaceCandidateRepository.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/place/repository/PlaceCandidateRepository.java
@@ -1,0 +1,17 @@
+package com.magicdev.manalgak.domain.place.repository;
+
+import com.magicdev.manalgak.domain.place.entity.PlaceCandidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, Long> {
+
+    List<PlaceCandidate> findByMeetingMeetingUuid(String meetingUuid);
+
+    boolean existsByMeetingMeetingUuid(String meetingUuid);
+
+    void deleteByMeetingMeetingUuid(String meetingUuid);
+}

--- a/backend/src/main/resources/db/migration/V5__create_place_candidates.sql
+++ b/backend/src/main/resources/db/migration/V5__create_place_candidates.sql
@@ -1,0 +1,25 @@
+-- V5: 추천 장소 후보 테이블 생성 (투표용 6개 매장 저장)
+
+CREATE TABLE IF NOT EXISTS place_candidates (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    meeting_id BIGINT NOT NULL,
+    place_id VARCHAR(100) NOT NULL,
+    place_name VARCHAR(200) NOT NULL,
+    category VARCHAR(50),
+    category_group_code VARCHAR(20),
+    category_group_name VARCHAR(100),
+    category_name VARCHAR(200),
+    address VARCHAR(500),
+    road_address VARCHAR(500),
+    latitude DOUBLE,
+    longitude DOUBLE,
+    distance INT,
+    walking_minutes INT,
+    phone VARCHAR(50),
+    place_url VARCHAR(500),
+    created_at DATETIME,
+    INDEX idx_place_candidates_meeting_id (meeting_id),
+    CONSTRAINT fk_place_candidates_meeting
+        FOREIGN KEY (meeting_id) REFERENCES meetings(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION

## 변경 사항
<!-- 뭐 했는지 한 줄 설명 -->
- PlaceCandidate 엔티티 및 레포지토리 추가
- PlaceService에 하이브리드 캐싱 로직 적용
  - Redis 캐시 확인 → DB 확인 → 카카오 API 호출
  - Redis 만료 시 DB에서 동일한 매장 복구
- place_candidates 테이블 마이그레이션 추가
- 투표 기능과 매장 목록 일관성 보장


## 관련 이슈
<!-- 사용 예시(closes #123, #124, #125) -->


## 테스트
- [x] 로컬에서 테스트 완료
- [x] 빌드 확인


<!-- 스크린샷이나 추가 설명 필요하면 여기에 -->
