### PR TITLE
Be/jong/place cache invalidation

### DIFF
--- a/backend/src/main/java/com/magicdev/manalgak/domain/participant/service/ParticipantServiceImpl.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/participant/service/ParticipantServiceImpl.java
@@ -12,6 +12,7 @@ import com.magicdev.manalgak.domain.participant.entity.Location;
 import com.magicdev.manalgak.domain.participant.entity.Participant;
 import com.magicdev.manalgak.domain.participant.repository.ParticipantRepository;
 import com.magicdev.manalgak.domain.participant.service.command.UpdateParticipantCommand;
+import com.magicdev.manalgak.domain.place.service.PlaceService;
 import com.magicdev.manalgak.domain.user.entity.User;
 import com.magicdev.manalgak.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class ParticipantServiceImpl implements ParticipantService {
     private final UserRepository userRepository;
     private final GeocodingService geoCodingService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final PlaceService placeService;
 
     private static final int MAX_COUNT = 10;
 
@@ -108,6 +110,9 @@ public class ParticipantServiceImpl implements ParticipantService {
                             command.getOriginAddress()
                     )
             );
+
+            // 출발지 변경 시 추천 장소 캐시 무효화
+            placeService.invalidatePlaceCache(meetingUuid);
         }
 
         if (command.getDestinationAddress() != null) {


### PR DESCRIPTION
## 변경 사항
<!-- 뭐 했는지 한 줄 설명 -->
참여자 주소 변경 시 추천 장소 캐시 무효화 및 중간지점 역 기반 검색으로 변경           

## 관련 이슈
<!-- 사용 예시(closes #123, #124, #125) -->
없음


## 테스트
- [x] 로컬에서 테스트 완료
- [x] 빌드 확인


<!-- 스크린샷이나 추가 설명 필요하면 여기에 -->
 - PlaceService: 기하학적 중심점 → 중간지점 역 기반 검색으로 변경                                                                                                                                                                 
  - PlaceService: invalidatePlaceCache() 메서드 추가                                                                                                                                                                               
  - ParticipantServiceImpl: 출발지 변경 시 캐시 무효화 호출 추가       