### PR TITLE
[FE][유리] 로컬머지후 수정재작업 (리스트, step 2 3 4, 확정)

### DIFF
--- a/frontend/src/app/meetings/[meetingId]/complete/page.tsx
+++ b/frontend/src/app/meetings/[meetingId]/complete/page.tsx
@@ -3,11 +3,10 @@
 
 import { use } from "react";
 import { useSearchParams } from "next/navigation";
-import CompleteSummaryDrawer from '@/components/meeting/Step6/CompleteSummaryDrawer'
+import CompleteSummaryDrawer from "@/components/meeting/Step6/CompleteSummaryDrawer";
 import CompleteMapSection from "@/components/meeting/Step6/CompleteMapSection";
 import { useMeetingComplete } from "@/lib/hooks/useMeetingComplete";
-import { useUser } from "@/context/UserContext";
-import LoginRequired from "@/components/common/LoginRequired";
+
 interface PageProps {
   params: Promise<{
     meetingId: string;
@@ -16,7 +15,6 @@ interface PageProps {
 
 export default function MeetingCompletePage({ params }: PageProps) {
   // ✅ Next.js 15 방식
-  const { user } = useUser();
   const { meetingId } = use(params);
   const searchParams = useSearchParams();
   const candidateIdParam = searchParams.get("candidateId");
@@ -24,10 +22,12 @@ export default function MeetingCompletePage({ params }: PageProps) {
   const resolvedCandidateId = Number.isFinite(candidateId)
     ? candidateId
     : undefined;
+
   const { data, isLoading, error } = useMeetingComplete(
     meetingId,
     resolvedCandidateId
   );
+
   const resolvedData = !isLoading && !error ? data : null;
 
   const meeting = {
@@ -42,34 +42,32 @@ export default function MeetingCompletePage({ params }: PageProps) {
     phoneNumber: resolvedData?.phoneNumber ?? "",
     organizerId: Number(resolvedData?.organizerId ?? 0),
   };
-    if (!user) {
-      const currentUrl = `/meetings/${meetingId}/complete`;
-      localStorage.setItem("loginRedirect", currentUrl);
-      return <LoginRequired />;
-    }
+
   return (
     <main className="relative min-h-[100dvh] w-full overflow-visible bg-[var(--bg)]">
       {/* 배경 지도 */}
       <CompleteMapSection
-        meetingUuid={meetingId}
+        meetingUuid={meetingId} // ✅ 1/30[유리] - CompleteMapSection 필수 props 명시 전달
         lat={resolvedData?.lat}
         lng={resolvedData?.lng}
         placeName={resolvedData?.placeName}
       />
 
-      {/* 지도 위 상단 타이틀 */}
-      <section className="pointer-events-none absolute left-0 right-0 top-16 z-20 flex flex-col items-center gap-1 px-4">
-        {/* Header는 카드 대신 타이포로 분리 */}
-        <h1 className="text-lg font-semibold tracking-tight text-[var(--text)] drop-shadow-sm">
-          모임 확정
-        </h1>
-        <p className="text-xs text-[var(--text-subtle)] drop-shadow-sm">
-          확정된 장소와 이동 정보를 확인하세요.
-        </p>
+      {/* 1/30[유리] - 타이틀 좌측 정렬 + 배경 추가로 가독성 개선 */}
+      <section className="pointer-events-none absolute left-0 right-0 top-16 z-20 px-4">
+        <div className="mx-auto max-w-[var(--app-max-width)] rounded-lg bg-[var(--bg-soft)] px-4 py-3 shadow-sm">
+          <h1 className="text-left text-lg font-semibold tracking-tight text-[var(--text)]">
+            모임 확정
+          </h1>
+          <p className="mt-1 text-left text-xs text-[var(--text-subtle)]">
+            확정된 장소와 이동 정보를 확인하세요.
+          </p>
+        </div>
       </section>
 
-      {/* 위에 올라오는 UI */}
-      <div className="relative z-10 pb-[calc(72px+env(safe-area-inset-bottom))]">
+      {/* 1/30[유리] - Drawer 폭을 app-container 기준으로 제한 */}
+      {/* 1/30[유리] - Bottom Navigation과 Drawer 하단 버튼 간 여백 확보 */}
+      <div className="relative z-10 mx-auto max-w-[var(--app-max-width)] pb-[calc(96px+env(safe-area-inset-bottom))]">
         <CompleteSummaryDrawer meeting={meeting} />
       </div>
     </main>

--- a/frontend/src/app/meetings/[meetingId]/complete/page.tsx
+++ b/frontend/src/app/meetings/[meetingId]/complete/page.tsx
@@ -7,6 +7,10 @@ import CompleteSummaryDrawer from "@/components/meeting/Step6/CompleteSummaryDra
 import CompleteMapSection from "@/components/meeting/Step6/CompleteMapSection";
 import { useMeetingComplete } from "@/lib/hooks/useMeetingComplete";
 
+// 🔧 로그인 가드
+import { useUser } from "@/context/UserContext";
+import LoginRequired from "@/components/common/LoginRequired";
+
 interface PageProps {
   params: Promise<{
     meetingId: string;
@@ -14,8 +18,14 @@ interface PageProps {
 }
 
 export default function MeetingCompletePage({ params }: PageProps) {
+  // =========================
+  // ✅ 모든 Hook은 최상단
+  // =========================
+  const { user } = useUser();
+
   // ✅ Next.js 15 방식
   const { meetingId } = use(params);
+
   const searchParams = useSearchParams();
   const candidateIdParam = searchParams.get("candidateId");
   const candidateId = candidateIdParam ? Number(candidateIdParam) : undefined;
@@ -28,6 +38,16 @@ export default function MeetingCompletePage({ params }: PageProps) {
     resolvedCandidateId
   );
 
+  // =========================
+  // ✅ 로그인 가드 (Hook 이후)
+  // =========================
+  if (!user) {
+    return <LoginRequired />;
+  }
+
+  // =========================
+  // 기존 로직 (변경 없음)
+  // =========================
   const resolvedData = !isLoading && !error ? data : null;
 
   const meeting = {
@@ -47,13 +67,13 @@ export default function MeetingCompletePage({ params }: PageProps) {
     <main className="relative min-h-[100dvh] w-full overflow-visible bg-[var(--bg)]">
       {/* 배경 지도 */}
       <CompleteMapSection
-        meetingUuid={meetingId} // ✅ 1/30[유리] - CompleteMapSection 필수 props 명시 전달
+        meetingUuid={meetingId}
         lat={resolvedData?.lat}
         lng={resolvedData?.lng}
         placeName={resolvedData?.placeName}
       />
 
-      {/* 1/30[유리] - 타이틀 좌측 정렬 + 배경 추가로 가독성 개선 */}
+      {/* 타이틀 */}
       <section className="pointer-events-none absolute left-0 right-0 top-16 z-20 px-4">
         <div className="mx-auto max-w-[var(--app-max-width)] rounded-lg bg-[var(--bg-soft)] px-4 py-3 shadow-sm">
           <h1 className="text-left text-lg font-semibold tracking-tight text-[var(--text)]">
@@ -65,8 +85,6 @@ export default function MeetingCompletePage({ params }: PageProps) {
         </div>
       </section>
 
-      {/* 1/30[유리] - Drawer 폭을 app-container 기준으로 제한 */}
-      {/* 1/30[유리] - Bottom Navigation과 Drawer 하단 버튼 간 여백 확보 */}
       <div className="relative z-10 mx-auto max-w-[var(--app-max-width)] pb-[calc(96px+env(safe-area-inset-bottom))]">
         <CompleteSummaryDrawer meeting={meeting} />
       </div>

--- a/frontend/src/app/meetings/new/page.tsx
+++ b/frontend/src/app/meetings/new/page.tsx
@@ -150,22 +150,41 @@ export default function CreateEntryPage() {
     );
   };
 
-  const handleDelete = async (uuid: string, organizerId: number) => {
-    if (user?.id !== organizerId) {
-      alert("모임장이 아닙니다.");
-      return;
-    }
+const handleDelete = async (uuid: string, organizerId: number) => {
+  if (user?.id !== organizerId) {
+    alert("모임장이 아닙니다.");
+    return;
+  }
 
-    if (!confirm("정말 이 모임을 삭제하시겠어요?")) return;
+  if (!confirm("정말 이 모임을 삭제하시겠어요?")) return;
 
+  try {
     await axios.delete(`${API_BASE_URL}/v1/meetings/${uuid}`, {
       withCredentials: true,
     });
 
+    // ✅ 리스트에서 제거
     setExistingMeetings((prev) =>
       prev.filter((item) => item.meeting.meetingUuid !== uuid)
     );
-  };
+
+    // ✅ 페이지네이션 정보 갱신
+    setPageInfo((prev) => {
+      if (!prev) return prev;
+
+      const nextTotal = Math.max(0, prev.totalElements - 1);
+
+      return {
+        ...prev,
+        totalElements: nextTotal,
+        empty: nextTotal === 0,
+      };
+    });
+  } catch (err) {
+    console.error("모임 삭제 실패:", err);
+    alert("모임 삭제에 실패했습니다.");
+  }
+};
 
   const formatDateTime = (dateString: string) => {
     const d = new Date(dateString);

--- a/frontend/src/app/meetings/new/page.tsx
+++ b/frontend/src/app/meetings/new/page.tsx
@@ -1,5 +1,5 @@
 // src/app/meetings/new/page.tsx
-// 모임 리스트 페이지 
+// 모임 리스트 페이지
 "use client";
 
 import { useEffect, useState, type ReactNode } from "react";
@@ -7,7 +7,12 @@ import axios from "axios";
 import { useRouter } from "next/navigation";
 import { useUser } from "@/context/UserContext";
 import { Button } from "@/components/ui/button";
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CalendarPlus, ChevronDown, Users } from "lucide-react";
 
@@ -30,19 +35,10 @@ interface Meeting {
   meetingTime: string;
   organizerId: number;
   totalParticipants: number;
-  status?: 'PENDING' | 'COMPLETED';
+  status?: "PENDING" | "COMPLETED";
   selectedPlace?: {
-    placeId?: string;
     placeName?: string;
-    address?: string;
-    latitude?: number;
-    longitude?: number;
   };
-  participants: Array<{
-    destination?: {
-      address?: string;
-    };
-  }>;
 }
 
 interface MeetingItem {
@@ -52,14 +48,14 @@ interface MeetingItem {
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080/api";
 
+/* ======================
+ * UI States
+ * ====================== */
 function EmptyState() {
   return (
     <div className="rounded-xl border border-dashed border-[var(--border)] bg-[var(--bg-soft)] px-4 py-6 text-center">
       <p className="text-sm text-[var(--text-subtle)]">
         아직 생성된 모임이 없습니다.
-      </p>
-      <p className="mt-1 text-xs text-[var(--text-subtle)]">
-        아래 버튼으로 새 모임을 만들어 보세요.
       </p>
     </div>
   );
@@ -69,13 +65,15 @@ function LoadingState() {
   return (
     <div className="space-y-3">
       <Skeleton className="h-5 w-40 bg-[var(--neutral-soft)]" />
-      <Skeleton className="h-4 w-64 bg-[var(--neutral-soft)]" />
       <Skeleton className="h-16 w-full bg-[var(--neutral-soft)]" />
       <Skeleton className="h-16 w-full bg-[var(--neutral-soft)]" />
     </div>
   );
 }
 
+/* ======================
+ * Page
+ * ====================== */
 export default function CreateEntryPage() {
   const router = useRouter();
   const { user } = useUser();
@@ -133,13 +131,12 @@ export default function CreateEntryPage() {
     fetchMeetings(next, true);
   };
 
-  const handleEdit = (uuid: string, organizerId: number) => {
-    const readonly = user?.id !== organizerId ? "&readonly=true" : "";
-    router.push(`/meetings/new/step3-meeting?meetingUuid=${uuid}${readonly}`);
-  };
-
-  const handleView = (meetingUuid: string) => {
-    router.push(`/meetings/${meetingUuid}/complete`);
+  /* ======================
+   * Navigation (FE only)
+   * ====================== */
+  const goToConfirmPage = (uuid: string) => {
+    // 1/30[유리] - 리스트/조회 클릭 시 확정 페이지로 이동
+    router.push(`/meetings/${uuid}/complete`);
   };
 
   const handleCopy = async (uuid: string) => {
@@ -154,34 +151,21 @@ export default function CreateEntryPage() {
   };
 
   const handleDelete = async (uuid: string, organizerId: number) => {
-    if (user?.id !== organizerId) return alert("모임장이 아닙니다.");
+    if (user?.id !== organizerId) {
+      alert("모임장이 아닙니다.");
+      return;
+    }
 
     if (!confirm("정말 이 모임을 삭제하시겠어요?")) return;
 
-     try {
-        await axios.delete(`${API_BASE_URL}/v1/meetings/${uuid}`, {
-          withCredentials: true,
-        });
+    await axios.delete(`${API_BASE_URL}/v1/meetings/${uuid}`, {
+      withCredentials: true,
+    });
 
-        setExistingMeetings((prev) =>
-          prev.filter((item) => item.meeting.meetingUuid !== uuid)
-        );
-
-        setPageInfo((prev) => {
-          if (!prev) return prev;
-
-          const nextTotal = Math.max(0, prev.totalElements - 1);
-
-          return {
-            ...prev,
-            totalElements: nextTotal,
-            empty: nextTotal === 0,
-          };
-        });
-      } catch {
-        alert("모임 삭제에 실패했습니다.");
-      }
-    };
+    setExistingMeetings((prev) =>
+      prev.filter((item) => item.meeting.meetingUuid !== uuid)
+    );
+  };
 
   const formatDateTime = (dateString: string) => {
     const d = new Date(dateString);
@@ -208,7 +192,10 @@ export default function CreateEntryPage() {
   }
 
   return (
-    <main className="min-h-[calc(100dvh-1px)] bg-[var(--bg)] px-4 py-6">
+    <main
+      className="min-h-[calc(100dvh-1px)] bg-[var(--bg)] px-4 py-6 pb-28 scroll-pt-20"
+      // 1/30[유리] - 바텀네비 및 헤더 가림 방지
+    >
       <div className="mx-auto w-full max-w-3xl space-y-4">
         {/* ===== Header ===== */}
         <section className="space-y-1">
@@ -221,38 +208,29 @@ export default function CreateEntryPage() {
         </section>
 
         {/* ===== Primary CTA ===== */}
-            <Button
-              onClick={() => router.push("/meetings/new/step1-basic")}
-              className="w-full flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] py-6"
-            >
-              <CalendarPlus className="h-5 w-5" />
-              모임 생성하기
-            </Button>
+        <Button
+          onClick={() => router.push("/meetings/new/step1-basic")}
+          className="w-full flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] py-6"
+        >
+          <CalendarPlus className="h-5 w-5" />
+          모임 생성하기
+        </Button>
 
-       {/* ===== List Section ===== */}
-      <section className="space-y-3">
-        {listState}
+        {/* ===== List Section ===== */}
+        <section className="space-y-3">
+          {listState}
 
           {!listState && (
             <div className="divide-y divide-[var(--border)] bg-[var(--bg)]">
               {existingMeetings.map(({ meeting }) => {
                 const isOrganizer = user?.id === meeting.organizerId;
-                const isCompleted = meeting.status === 'COMPLETED';
-
-                const primaryLabel = isCompleted ? "조회" : "수정";
-
-                const handlePrimaryAction = () => {
-                  if (isCompleted) {
-                    handleView(meeting.meetingUuid!);
-                  } else {
-                    handleEdit(meeting.meetingUuid!, meeting.organizerId);
-                  }
-                };
 
                 return (
                   <div
                     key={meeting.meetingUuid}
-                    className="px-0 py-3"
+                    className="px-0 py-3 cursor-pointer"
+                    onClick={() => goToConfirmPage(meeting.meetingUuid!)}
+                    // 1/30[유리] - 리스트 카드 클릭 시 확정 페이지 이동
                   >
                     <div className="flex items-start gap-4">
                       {/* ===== 인원수 영역 ===== */}
@@ -267,31 +245,15 @@ export default function CreateEntryPage() {
 
                       {/* ===== 텍스트 정보 ===== */}
                       <div className="flex-1 space-y-1">
-                        {/* 1줄: 모임명 + 상태 뱃지 */}
-                        <div className="flex items-center gap-2">
-                          <p className="text-base font-semibold text-[var(--text)] truncate">
-                            {meeting.meetingName}
-                          </p>
-                          {/* ✅ 모임장 뱃지 추가 */}
-                          {isOrganizer && (
-                            <span className="shrink-0 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-700">
-                              모임장
-                            </span>
-                          )}
-                          {isCompleted && (
-                            <span className="shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-medium text-green-700">
-                              확정
-                            </span>
-                          )}
-                        </div>
-
-                      {/* 2줄: 장소 · 날짜 */}
-                      <p className="text-sm text-[var(--text-subtle)]">
-                        {meeting.selectedPlace?.placeName || "장소 미정"}
-                        <span className="mx-2">·</span>
-                        {formatDateTime(meeting.meetingTime)}
-                      </p>
-                    </div>
+                        <p className="text-base font-semibold text-[var(--text)] truncate">
+                          {meeting.meetingName}
+                        </p>
+                        <p className="text-sm text-[var(--text-subtle)]">
+                          {meeting.selectedPlace?.placeName || "장소 미정"}
+                          <span className="mx-2">·</span>
+                          {formatDateTime(meeting.meetingTime)}
+                        </p>
+                      </div>
 
                       {/* ===== 액션 영역 ===== */}
                       <div className="shrink-0">
@@ -299,61 +261,75 @@ export default function CreateEntryPage() {
                         <div className="hidden sm:flex gap-2">
                           <Button
                             size="sm"
-                            onClick={handlePrimaryAction}
-                            className={
-                              isCompleted
-                                ? "bg-[var(--neutral-soft)] text-[var(--text)]"
-                                : "bg-[var(--primary)] text-[var(--primary-foreground)]"
-                            }
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              goToConfirmPage(meeting.meetingUuid!);
+                            }}
+                            // 1/30[유리] - 조회 버튼도 확정 페이지 이동
                           >
-                            {primaryLabel}
+                            조회
                           </Button>
 
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleCopy(meeting.meetingUuid!)}
-                        >
-                          복사
-                        </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleCopy(meeting.meetingUuid!);
+                            }}
+                          >
+                            복사
+                          </Button>
 
                           <Button
                             size="sm"
                             disabled={!isOrganizer}
-                            onClick={() =>
-                              handleDelete(meeting.meetingUuid!, meeting.organizerId)
-                            }
-                            className="bg-[var(--danger-soft)] text-[var(--danger)] disabled:opacity-40"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleDelete(
+                                meeting.meetingUuid!,
+                                meeting.organizerId
+                              );
+                            }}
+                            className="bg-[var(--danger-soft)] text-[var(--danger)]"
                           >
                             삭제
                           </Button>
                         </div>
 
-                      {/* 모바일 … 메뉴 */}
-                      <div className="sm:hidden">
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              className="p-2 rounded-md hover:bg-[var(--bg-soft)]"
-                              aria-label="더보기"
-                            >
-                              …
-                            </button>
-                          </DropdownMenuTrigger>
+                        {/* 모바일 … 메뉴 */}
+                        <div className="sm:hidden">
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                className="p-2 rounded-md hover:bg-[var(--bg-soft)]"
+                                aria-label="더보기"
+                              >
+                                …
+                              </button>
+                            </DropdownMenuTrigger>
 
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem onClick={handlePrimaryAction}>
-                                {primaryLabel}
+                            <DropdownMenuContent
+                              align="end"
+                              className="bg-[var(--bg)] border border-[var(--border)]"
+                              // 1/30[유리] - 모바일 메뉴 배경 투명 문제 해결
+                            >
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  goToConfirmPage(meeting.meetingUuid!)
+                                }
+                              >
+                                조회
                               </DropdownMenuItem>
 
-                            <DropdownMenuItem
-                              onClick={() => handleCopy(meeting.meetingUuid!)}
-                            >
-                              복사
-                            </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onClick={() => handleCopy(meeting.meetingUuid!)}
+                              >
+                                복사
+                              </DropdownMenuItem>
 
                               <DropdownMenuItem
-                                disabled={!isOrganizer || isCompleted}
+                                disabled={!isOrganizer}
                                 onClick={() =>
                                   handleDelete(
                                     meeting.meetingUuid!,
@@ -376,26 +352,23 @@ export default function CreateEntryPage() {
           )}
         </section>
 
-
-
-       
         {/* ===== Pagination ===== */}
         {pageInfo && !pageInfo.last && (
-            <div className="flex flex-col items-center gap-2 py-4">
-              <Button
-                onClick={handleLoadMore}
-                disabled={isLoadingMore}
-                variant="outline"
-                className="w-full max-w-sm border-[var(--border)] bg-[var(--bg)] text-[var(--text)]"
-              >
-                {isLoadingMore ? "불러오는 중…" : "더보기"}
-                <ChevronDown className="ml-2 h-4 w-4" />
-              </Button>
+          <div className="flex flex-col items-center gap-2 py-4">
+            <Button
+              onClick={handleLoadMore}
+              disabled={isLoadingMore}
+              variant="outline"
+              className="w-full max-w-sm border-[var(--border)] bg-[var(--bg)] text-[var(--text)]"
+            >
+              {isLoadingMore ? "불러오는 중…" : "더보기"}
+              <ChevronDown className="ml-2 h-4 w-4" />
+            </Button>
 
-              <p className="text-xs text-[var(--text-subtle)]">
-                {existingMeetings.length} 개 / 총 {pageInfo.totalElements} 개
-              </p>
-            </div>
+            <p className="text-xs text-[var(--text-subtle)]">
+              {existingMeetings.length} 개 / 총 {pageInfo.totalElements} 개
+            </p>
+          </div>
         )}
       </div>
     </main>

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -14,7 +14,6 @@ import CompletedMeetingNotice from "@/components/common/CompletedMeetingNotice";
 import RequireMeeting from "@/components/common/RequireMeeting";
 import { useUser } from "@/context/UserContext";
 
-
 // shadcn/ui
 import {
   Card,
@@ -131,8 +130,6 @@ function Step3MembersContent(): JSX.Element {
 
   const { user, loading } = useUser();
 
-  // const [originAddress, setOriginAddress] = useState("");
-  // const [transport, setTransport] = useState<TransportMode | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [myParticipantId, setMyParticipantId] = useState<number | null>(null);
   const [meetingData, setMeetingData] = useState<MeetingData | null>(null);
@@ -172,12 +169,6 @@ function Step3MembersContent(): JSX.Element {
 
         if (myParticipant) {
           setMyParticipantId(myParticipant.participantId);
-          // if (myParticipant.origin?.address) {
-          //   setOriginAddress(myParticipant.origin.address);
-          // }
-          // if (myParticipant.transportType) {
-          //   setTransport(myParticipant.transportType);
-          // }
         } else {
           try {
             await axios.post(
@@ -201,19 +192,14 @@ function Step3MembersContent(): JSX.Element {
               setMyParticipantId(newParticipant.participantId);
             }
           } catch (err: unknown) {
-            console.error("참여 생성 실패", err);
-
             if (axios.isAxiosError(err) && err.response?.status === 400) {
               const errorCode = err.response?.data?.error?.code;
-
               if (errorCode === "MEETING_EXPIRED") {
                 setIsExpired(true);
               }
             }
           }
         }
-      } catch (e) {
-        console.error("모임 조회 실패", e);
       } finally {
         setIsLoading(false);
       }
@@ -225,11 +211,9 @@ function Step3MembersContent(): JSX.Element {
   // =====================
   // 예외 케이스 UI
   // =====================
-  if (!meetingUuid) {
-    return <RequireMeeting />;
-  }
+  if (!meetingUuid) return <RequireMeeting />;
 
-  if (loading) {
+  if (loading || isLoading) {
     return (
       <div className="mx-auto max-w-xl space-y-4 py-20">
         <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
@@ -244,49 +228,30 @@ function Step3MembersContent(): JSX.Element {
     return <LoginRequired />;
   }
 
-  if (isLoading) {
-    return (
-      <div className="mx-auto max-w-xl space-y-4 py-20">
-        <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
-        <Skeleton className="h-40 w-full rounded-xl bg-[var(--neutral-soft)]" />
-      </div>
-    );
-  }
-
-  // ⭐ COMPLETED 상태 체크 - 확정된 모임 안내 카드 표시
-  if (meetingData?.status === 'COMPLETED') {
+  if (meetingData?.status === "COMPLETED") {
     return <CompletedMeetingNotice meetingUuid={meetingUuid} />;
   }
 
-  // ⭐ 만료된 모임 카드 UI
- if (isExpired) {
-   return (
-     <main className="flex min-h-[60vh] items-center justify-center p-6">
-       <Card className="w-full max-w-md text-center border-red-200 dark:border-red-700 bg-[var(--bg-soft)] shadow-md">
-         <CardHeader className="space-y-3">
-           <div className="text-4xl">⏰</div>
-           <CardTitle className="text-red-600 dark:text-red-400 text-xl font-semibold">
-             이미 만료된 모임입니다
-           </CardTitle>
-           <CardDescription className="text-[var(--text-subtle)] leading-relaxed">
-             이 모임은 참여 기한이 지나
-             <br />
-             새로운 참여자를 받을 수 없습니다.
-           </CardDescription>
-         </CardHeader>
-
-         <CardContent>
-           <Button
-             className="w-full bg-[var(--primary)] text-[var(--primary-foreground)]"
-             onClick={() => router.push("/meetings/new")}
-           >
-             모임 리스트로 이동
-           </Button>
-         </CardContent>
-       </Card>
-     </main>
-   );
- }
+  if (isExpired) {
+    return (
+      <main className="flex min-h-[60vh] items-center justify-center p-6">
+        <Card className="w-full max-w-md text-center bg-[var(--bg-soft)] shadow-none">
+          {/* 1/30[유리] - 카드 그림자 제거 */}
+          <CardHeader>
+            <CardTitle>이미 만료된 모임입니다</CardTitle>
+            <CardDescription>
+              이 모임은 참여 기한이 지났습니다.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => router.push("/meetings/new")}>
+              모임 리스트로 이동
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
 
   // =====================
   // 정상 화면
@@ -294,69 +259,66 @@ function Step3MembersContent(): JSX.Element {
   return (
     <>
       <main className="mx-auto max-w-xl space-y-6">
-        {/* ===== Header ===== */}
-        <section className="space-y-1">
-          <h2 className="text-lg font-semibold text-[var(--text)]">
-             참여자
-          </h2>
+        <section>
+          <h2 className="text-lg font-semibold">참여자</h2>
           <p className="text-sm text-[var(--text-subtle)]">
             멤버를 초대하세요.
           </p>
         </section>
 
-        {/* 초대 CTA */}
         <Button
-              className="w-full gap-2 py-6 rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)]"
-              disabled={isReadonly || !isOrganizer}
-              onClick={() => {
-                if (!meetingData) return;
-                sendKakaoInvite(
-                  meetingUuid,
-                  meetingData.meetingName,
-                  meetingData.meetingTime
-                );
-              }}
-            >
-              <Send size={18} />
-              {isOrganizer
-                ? "참여 멤버 초대"
-                : "모임장만 멤버를 초대할 수 있어요"}
-            </Button>
+          className="w-full gap-2 py-6 rounded-xl bg-[var(--kakao-yellow)] text-black"
+          disabled={isReadonly || !isOrganizer}
+          onClick={() => {
+            if (!meetingData) return;
+            sendKakaoInvite(
+              meetingUuid,
+              meetingData.meetingName,
+              meetingData.meetingTime
+            );
+          }}
+        >
+          {/* 1/30[유리] - 카카오 컬러 토큰 적용 */}
+          <Send size={18} />
+          참여 멤버 초대
+        </Button>
 
+        <p className="text-xs text-[var(--text-subtle)]">
+          참여자 리스트에는 현재 로그인한 사용자만 표시됩니다.
+        </p>
+        {/* 1/30[유리] - 참여자 표시 기준 안내 */}
 
+        <Card className="bg-[var(--bg-soft)] shadow-none">
+          {/* 1/30[유리] - 교통편/주소 비노출 및 닉네임 중심 안내 */}
+          <CardContent className="text-sm text-[var(--text-subtle)]">
+            이 단계에서는 닉네임을 기준으로 참여자가 표시됩니다.
+          </CardContent>
+        </Card>
 
-        {/* 멤버 리스트 */}
-            <MemberList
-              meetingUuid={meetingUuid}
-              userId={user.id}
-              onMyParticipantResolved={(id) => {
-                if (!myParticipantId) {
-                  setMyParticipantId(id);
-                }
-              }}
-              readonly={isReadonly}
-            />
-
+        <MemberList
+          meetingUuid={meetingUuid}
+          userId={user.id}
+          onMyParticipantResolved={(id) => {
+            if (!myParticipantId) setMyParticipantId(id);
+          }}
+          readonly={isReadonly}
+        />
       </main>
 
-      <StepNavigation
-        prevHref={prevHref}
-        nextHref={`/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`}
-        onNext={async () => {
-          if (meetingData?.status === "COMPLETED") {
+      <div className="mt-10">
+        {/* 1/30[유리] - 하단 버튼 영역 상단 여백 추가 */}
+        <StepNavigation
+          prevHref={prevHref}
+          nextHref={`/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`}
+          onNext={async () => {
+            if (!myParticipantId) {
+              alert("참여자 정보가 아직 준비되지 않았어요.");
+              throw new Error("participantId 없음");
+            }
             return `/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`;
-          }
-
-          if (!myParticipantId) {
-            alert("참여자 정보가 아직 준비되지 않았어요.");
-            throw new Error("participantId 없음");
-          }
-
-          // ✅ Step2에서는 여기서 끝
-          return `/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`;
-        }}
-      />
-
+          }}
+        />
+      </div>
     </>
   );
 }

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -1,4 +1,4 @@
-// src/app/meetings/new/step2-meetingmembers/page.tsx
+// src/app/meetings/new/step2-members/page.tsx
 "use client";
 
 import { useEffect, useState, useRef, Suspense } from "react";
@@ -192,8 +192,11 @@ function Step3MembersContent(): JSX.Element {
               setMyParticipantId(newParticipant.participantId);
             }
           } catch (err: unknown) {
+            console.error("참여 생성 실패", err);
+
             if (axios.isAxiosError(err) && err.response?.status === 400) {
               const errorCode = err.response?.data?.error?.code;
+
               if (errorCode === "MEETING_EXPIRED") {
                 setIsExpired(true);
               }

--- a/frontend/src/app/meetings/new/step3-meeting/page.tsx
+++ b/frontend/src/app/meetings/new/step3-meeting/page.tsx
@@ -1,4 +1,4 @@
-// src/app/meetings/new/step2-meetingmembers/page.tsx
+// src/app/meetings/new/step3-meeting/page.tsx
 "use client";
 
 import { useEffect, useState, useRef, Suspense } from "react";
@@ -126,11 +126,14 @@ function Step3MembersContent(): JSX.Element {
   const [myParticipantId, setMyParticipantId] = useState<number | null>(null);
   const [meetingData, setMeetingData] = useState<MeetingData | null>(null);
 
+  const [openFetchModal, setOpenFetchModal] = useState(false);
+  // 1/30[유리] - [가져오기] 버튼 모달 트리거 상태 추가
+
   const joinedRef = useRef(false);
 
   const isReadonly = meetingData?.status === "COMPLETED";
- // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const isOrganizer = meetingData?.organizerId === user?.id;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const isOrganizer = meetingData?.organizerId === user?.id;
 
   const prevHref = `/meetings/new/step2-members?meetingUuid=${meetingUuid}${
     readonlyParam ? "&readonly=true" : ""
@@ -202,9 +205,9 @@ const isOrganizer = meetingData?.organizerId === user?.id;
   // =====================
   // 예외 케이스 UI
   // =====================
-   if (!meetingUuid) {
-     return <RequireMeeting />;
-   }
+  if (!meetingUuid) {
+    return <RequireMeeting />;
+  }
 
   if (loading) {
     return (
@@ -221,7 +224,7 @@ const isOrganizer = meetingData?.organizerId === user?.id;
     return <LoginRequired />;
   }
 
-  if (meetingData?.status === 'COMPLETED') {
+  if (meetingData?.status === "COMPLETED") {
     return <CompletedMeetingNotice meetingUuid={meetingUuid} />;
   }
 
@@ -234,60 +237,118 @@ const isOrganizer = meetingData?.organizerId === user?.id;
         {/* ===== Header ===== */}
         <section className="space-y-1">
           <h2 className="text-lg font-semibold text-[var(--text)]">
-             출발지와 교통편을 선택하세요
+            출발지와 교통편을 선택하세요
           </h2>
           <p className="text-sm text-[var(--text-subtle)]">
             출발지·교통수단을 설정하세요.
           </p>
         </section>
 
+        <div className="border-b border-[var(--border)]" />
+        {/* 1/30[유리] - 카드 UI 제거 후 구분선만 유지 */}
+
+        {/* 나의 출발지 입력 / 가져오기 */}
+        <div className="flex items-center justify-between">
+          {/* 1/30[유리] - 한 줄(Row) 정렬 */}
+          <span className="text-sm font-medium text-[var(--text)]">
+            나의 출발지 입력
+          </span>
+          <button
+            type="button"
+            onClick={() => setOpenFetchModal(true)}
+            className="rounded-full border border-[var(--border)] bg-[var(--bg-soft)] px-4 py-2 text-sm text-[var(--text)]"
+          >
+            가져오기
+          </button>
+          {/* 1/30[유리] - 모달 트리거 버튼 + rounded-full */}
+        </div>
 
         {/* 주소 입력 */}
-            {isLoading ? (
-              <Skeleton className="h-32 w-full rounded-xl bg-[var(--neutral-soft)]" />
-            ) : (
-              <Address
-                originAddress={originAddress}
-                setOriginAddress={setOriginAddress}
-                transport={transport}
-                setTransport={setTransport}
-                readonly={isReadonly}
-              />
-            )}
-       
+        {isLoading ? (
+          <Skeleton className="h-32 w-full rounded-xl bg-[var(--neutral-soft)]" />
+        ) : (
+          <Address
+            originAddress={originAddress}
+            setOriginAddress={setOriginAddress}
+            transport={transport}
+            setTransport={setTransport}
+            readonly={isReadonly}
+          />
+        )}
 
+        <div className="border-b border-[var(--border)]" />
+        {/* 1/30[유리] - 콘텐츠 하단 구분선 추가 */}
       </main>
 
-      <StepNavigation
-        prevHref={prevHref}
-        nextHref={`/meetings/new/step3-result?meetingUuid=${meetingUuid}`}
-        onNext={async () => {
-          if (meetingData?.status === "COMPLETED") {
-            return `/meetings/new/step3-result?meetingUuid=${meetingUuid}`;
-          }
+      {/* 콘텐츠와 이전/다음 버튼 간 여백 */}
+      <div className="mt-10">
+        {/* 1/30[유리] - StepNavigation과 콘텐츠 사이 여백 추가 */}
+        <StepNavigation
+          prevHref={prevHref}
+          nextHref={`/meetings/new/step3-result?meetingUuid=${meetingUuid}`}
+          onNext={async () => {
+            if (meetingData?.status === "COMPLETED") {
+              return `/meetings/new/step3-result?meetingUuid=${meetingUuid}`;
+            }
 
-          if (!myParticipantId) {
-            alert("참여자 정보가 아직 준비되지 않았어요.");
-            throw new Error("participantId 없음");
-          }
+            if (!myParticipantId) {
+              alert("참여자 정보가 아직 준비되지 않았어요.");
+              throw new Error("participantId 없음");
+            }
 
-          if (!transport || !originAddress) {
-            alert("출발지와 이동수단을 입력해주세요.");
-            throw new Error("입력값 부족");
-          }
+            if (!transport || !originAddress) {
+              alert("출발지와 이동수단을 입력해주세요.");
+              throw new Error("입력값 부족");
+            }
 
-          await axios.patch(
-            `${process.env.NEXT_PUBLIC_API_BASE_URL}/v1/meetings/${meetingUuid}/participants/${myParticipantId}`,
-            {
-              type: transport,
-              originAddress,
-            },
-            { withCredentials: true }
-          );
+            await axios.patch(
+              `${process.env.NEXT_PUBLIC_API_BASE_URL}/v1/meetings/${meetingUuid}/participants/${myParticipantId}`,
+              {
+                type: transport,
+                originAddress,
+              },
+              { withCredentials: true }
+            );
 
-          return `/meetings/new/step4-result?meetingUuid=${meetingUuid}`;
-        }}
-      />
+            return `/meetings/new/step4-result?meetingUuid=${meetingUuid}`;
+          }}
+        />
+      </div>
+
+      {/* 모달 + 오버레이 */}
+      {openFetchModal ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* 1/30[유리] - 전체 배경 오버레이 (검정 70%) */}
+          <button
+            type="button"
+            aria-label="모달 닫기"
+            className="absolute inset-0 bg-black/70"
+            onClick={() => setOpenFetchModal(false)}
+          />
+          <div className="relative z-10 w-[min(92vw,420px)] rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4">
+            {/* 1/30[유리] - 오버레이 위 모달 카드 */}
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold text-[var(--text)]">
+                출발지 가져오기
+              </p>
+              <button
+                type="button"
+                onClick={() => setOpenFetchModal(false)}
+                className="rounded-full border border-[var(--border)] bg-[var(--bg-soft)] px-3 py-1 text-sm"
+              >
+                닫기
+              </button>
+            </div>
+
+            <div className="mt-3 border-b border-[var(--border)]" />
+
+            <div className="mt-3 text-sm text-[var(--text-subtle)]">
+              가져오기 UI 전용 모달입니다. 실제 데이터 연동은 별도 구현이
+              필요합니다.
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/frontend/src/app/meetings/new/step4-result/page.tsx
+++ b/frontend/src/app/meetings/new/step4-result/page.tsx
@@ -1,22 +1,16 @@
 // src/app/meetings/new/step4-result/page.tsx
 "use client";
 
-import { useState,Suspense } from "react";
+import { useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 
 // 기존 로직 컴포넌트 (변경 없음)
-import StepNavigation from "@/components/layout/StepNavigation";
 import Step3PlaceList from "@/components/meeting/Step3/Step3PlaceList";
 
 // shadcn/ui
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+
 import CompletedMeetingNotice from "@/components/common/CompletedMeetingNotice";
 import RequireMeeting from "@/components/common/RequireMeeting";
 
@@ -24,58 +18,62 @@ function Step3Content(): JSX.Element {
   const searchParams = useSearchParams();
   const meetingUuid = searchParams.get("meetingUuid");
   const [meetingStatus, setMeetingStatus] = useState<string | null>(null);
+
   // =====================
   // meetingUuid 없음 (Empty State)
   // =====================
   if (!meetingUuid) {
     return <RequireMeeting />;
   }
-  if (meetingStatus === 'COMPLETED' && meetingUuid) {
-    return <CompletedMeetingNotice meetingUuid={meetingUuid} />
+
+  if (meetingStatus === "COMPLETED" && meetingUuid) {
+    return <CompletedMeetingNotice meetingUuid={meetingUuid} />;
   }
+
   // =====================
   // 정상 화면
   // =====================
   return (
     <>
-      <main className="mx-auto max-w-xl space-y-6 pb-28">
+      <main className="mx-auto max-w-xl pb-28">
         {/* 헤더 */}
-        <Card className="border-[var(--border)] bg-[var(--bg-soft)]">
-          <CardHeader>
-            <CardTitle className="text-[var(--text)]">
-              추천 장소 확정
-            </CardTitle>
-            <CardDescription className="text-[var(--text-subtle)]">
-              참여 멤버들의 중간지점과 추천 장소를 확인하고,
-              최종 장소를 확정할 수 있어요.
-            </CardDescription>
-          </CardHeader>
-        </Card>
+        {/* 1/30[유리] - 타이틀을 감싸는 카드/박스 시각적 요소 제거 (구조 유지) */}
+        <header className="mb-6">
+          <h1 className="text-lg font-semibold text-[var(--text)]">
+            추천 장소 확정
+          </h1>
+          <p className="mt-1 text-sm text-[var(--text-subtle)]">
+            참여 멤버들의 중간지점과 추천 장소를 확인하고,
+            최종 장소를 확정할 수 있어요.
+          </p>
+        </header>
 
         {/* 장소 리스트 */}
-        <Card className="border-[var(--border)] bg-[var(--bg-soft)]">
-          <CardContent className="pt-6">
-            <Suspense
-              fallback={
-                <div className="space-y-3">
-                  <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
-                  <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
-                  <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
-                </div>
-              }
-            >
-             <Step3PlaceList onStatusLoaded={setMeetingStatus} />
-            </Suspense>
-          </CardContent>
-        </Card>
+        {/* 1/30[유리] - 외곽 카드 제거, 콘텐츠 영역만 유지 */}
+        <section>
+          <Suspense
+            fallback={
+              <div className="space-y-3">
+                <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
+                <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
+                <Skeleton className="h-24 w-full rounded-xl bg-[var(--neutral-soft)]" />
+              </div>
+            }
+          >
+            <Step3PlaceList onStatusLoaded={setMeetingStatus} />
+          </Suspense>
+        </section>
       </main>
 
-      {/* 하단 네비게이션 */}
-      <StepNavigation
-        prevHref={`/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`}
-        nextHref={`/meetings/${meetingUuid}/complete`}
-        nextLabel="확정 내용 확인"
-      />
+      {/* 하단 CTA */}
+      {/* 1/30[유리] - 기존 이전/다음 네비게이션 제거, 단일 [추천장소확정] 버튼으로 교체 */}
+      <div className="fixed bottom-0 left-0 right-0 z-10 border-t border-[var(--border)] bg-[var(--bg)] px-4 py-3">
+        <Button
+          className="w-full py-6 text-base font-medium bg-[var(--danger)] text-white"
+        >
+          추천장소확정
+        </Button>
+      </div>
     </>
   );
 }

--- a/frontend/src/app/meetings/new/step4-result/page.tsx
+++ b/frontend/src/app/meetings/new/step4-result/page.tsx
@@ -9,7 +9,6 @@ import Step3PlaceList from "@/components/meeting/Step3/Step3PlaceList";
 
 // shadcn/ui
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 
 import CompletedMeetingNotice from "@/components/common/CompletedMeetingNotice";
 import RequireMeeting from "@/components/common/RequireMeeting";
@@ -65,15 +64,9 @@ function Step3Content(): JSX.Element {
         </section>
       </main>
 
-      {/* 하단 CTA */}
-      {/* 1/30[유리] - 기존 이전/다음 네비게이션 제거, 단일 [추천장소확정] 버튼으로 교체 */}
-      <div className="fixed bottom-0 left-0 right-0 z-10 border-t border-[var(--border)] bg-[var(--bg)] px-4 py-3">
-        <Button
-          className="w-full py-6 text-base font-medium bg-[var(--danger)] text-white"
-        >
-          추천장소확정
-        </Button>
-      </div>
+      {/* 하단 CTA 제거
+          - 실제 추천장소 확정은 CompleteSummaryDrawer 내부 버튼에서 처리됨
+          - 중복/비동작 CTA 제거 */}
     </>
   );
 }

--- a/frontend/src/components/meeting/Step3/CompleteSummaryDrawer.tsx
+++ b/frontend/src/components/meeting/Step3/CompleteSummaryDrawer.tsx
@@ -9,31 +9,50 @@ import {
   DrawerFooter,
 } from '@/components/ui/drawer'
 import { X } from 'lucide-react'
-import PlaceInfoSection from '@/components/meeting/Step3/PlaceInfoSection'
+import PlaceInfoSection, {
+  PlaceInfo,
+} from '@/components/meeting/Step3/PlaceInfoSection'
 import TravelTimeSection from '@/components/meeting/Step3/TravelTimeSection'
 
 // shadcn/ui
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 
-interface MemberTravel {
+export interface MemberTravel {
   name: string
   minutes: number
   transfers: number
 }
 
+export interface ConfirmedPlaceSummary extends PlaceInfo {
+  stationName?: string | null
+  walkingMinutes?: number | null
+  kakaoMapUrl?: string | null
+}
+
 interface Props {
   open: boolean
   onClose: () => void
+  place?: ConfirmedPlaceSummary | null
+  members?: MemberTravel[]
 }
 
-export default function CompleteSummaryDrawer({ open, onClose }: Props) {
-  const members: MemberTravel[] = [
-    { name: '나', minutes: 35, transfers: 1 },
-    { name: '현수', minutes: 25, transfers: 2 },
-    { name: '영희', minutes: 24, transfers: 1 },
-    { name: '민수', minutes: 28, transfers: 1 },
-  ]
+export default function CompleteSummaryDrawer({
+  open,
+  onClose,
+  place,
+  members,
+}: Props) {
+  const walkingMinutes =
+    typeof place?.walkingMinutes === 'number' ? place.walkingMinutes : null
+  const stationName = place?.stationName?.trim() || null
+  const walkSummary =
+    stationName && walkingMinutes != null
+      ? `${stationName}에서 도보 ${walkingMinutes}분`
+      : null
+
+  const kakaoMapUrl = place?.kakaoMapUrl?.trim() || null
+  const canOpenKakaoMap = Boolean(kakaoMapUrl)
 
   return (
     <Drawer open={open} onOpenChange={(v) => !v && onClose()}>
@@ -62,10 +81,12 @@ export default function CompleteSummaryDrawer({ open, onClose }: Props) {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <PlaceInfoSection />
-              <p className="text-sm text-[var(--text-subtle)]">
-                을지로입구역에서 도보 5분
-              </p>
+              <PlaceInfoSection place={place} />
+              {walkSummary && (
+                <p className="text-sm text-[var(--text-subtle)]">
+                  {walkSummary}
+                </p>
+              )}
             </CardContent>
           </Card>
 
@@ -76,14 +97,21 @@ export default function CompleteSummaryDrawer({ open, onClose }: Props) {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <TravelTimeSection members={members} />
+              <TravelTimeSection members={members ?? []} />
             </CardContent>
           </Card>
         </div>
 
         {/* Footer CTA */}
         <DrawerFooter className="border-t border-[var(--border)] bg-[var(--bg)]">
-          <Button className="h-12 w-full bg-[var(--primary)] text-[var(--primary-foreground)]">
+          <Button
+            disabled={!canOpenKakaoMap}
+            onClick={() => {
+              if (!kakaoMapUrl) return
+              window.open(kakaoMapUrl, '_blank', 'noopener,noreferrer')
+            }}
+            className="h-12 w-full bg-[var(--primary)] text-[var(--primary-foreground)] disabled:opacity-40"
+          >
             카카오맵에서 길찾기
           </Button>
         </DrawerFooter>

--- a/frontend/src/components/meeting/Step3/PlaceInfoSection.tsx
+++ b/frontend/src/components/meeting/Step3/PlaceInfoSection.tsx
@@ -1,3 +1,4 @@
+// src/components/meeting/Step3/PlaceInfoSection.tsx
 'use client'
 
 // shadcn/ui

--- a/frontend/src/components/meeting/Step3/PlaceInfoSection.tsx
+++ b/frontend/src/components/meeting/Step3/PlaceInfoSection.tsx
@@ -9,16 +9,32 @@ import {
   CardContent,
 } from '@/components/ui/card'
 
-export default function PlaceInfoSection(): JSX.Element {
+export interface PlaceInfo {
+  placeName?: string | null
+  categoryName?: string | null
+  address?: string | null
+  phone?: string | null
+}
+
+interface Props {
+  place?: PlaceInfo | null
+}
+
+export default function PlaceInfoSection({ place }: Props): JSX.Element {
+  const placeName = place?.placeName?.trim() || '-'
+  const categoryName = place?.categoryName?.trim() || '-'
+  const address = place?.address?.trim() || '-'
+  const phone = place?.phone?.trim() || '-'
+
   return (
     <Card className="border border-[var(--border)] bg-[var(--bg-soft)]">
       {/* 장소 기본 정보 */}
       <CardHeader className="space-y-1">
         <CardTitle className="text-[var(--text)] text-base">
-          마하 한남
+          {placeName}
         </CardTitle>
         <CardDescription className="text-[var(--text-subtle)]">
-          이탈리안 레스토랑
+          {categoryName}
         </CardDescription>
       </CardHeader>
 
@@ -28,14 +44,14 @@ export default function PlaceInfoSection(): JSX.Element {
           <div>
             <p className="text-xs text-[var(--text-subtle)]">주소</p>
             <p className="text-sm text-[var(--text)]">
-              서울 중구 을지로 170-1
+              {address}
             </p>
           </div>
 
           <div>
             <p className="text-xs text-[var(--text-subtle)]">전화</p>
             <p className="text-sm text-[var(--text)]">
-              02-2266-1234
+              {phone}
             </p>
           </div>
         </div>

--- a/frontend/src/components/meeting/Step3/Step3PlaceList.tsx
+++ b/frontend/src/components/meeting/Step3/Step3PlaceList.tsx
@@ -194,16 +194,6 @@ function pickIconById(category: PlaceCategory, id: string): LucideIcon {
   return icons[hash % icons.length]
 }
 
-/* ================= FE 더미 추천장소 (fallback) ================= */
-const rawPlaces: Omit<RecommendedPlace, 'icon'>[] = [
-  { id: 'p1', name: '추천 카페', category: 'cafe', stationName: '을지로입구역', walkingMinutes: 5 },
-  { id: 'p2', name: '추천 식당 A', category: 'restaurant', stationName: '종각역', walkingMinutes: 7 },
-  { id: 'p3', name: '추천 식당 B', category: 'restaurant', stationName: '종로3가역', walkingMinutes: 10 },
-  { id: 'p4', name: '추천 전시관', category: 'culture', stationName: '을지로3가역', walkingMinutes: 12 },
-  { id: 'p5', name: '추천 명소', category: 'tour', stationName: '명동역', walkingMinutes: 15 },
-  { id: 'p6', name: '추천 카페 B', category: 'cafe', stationName: '시청역', walkingMinutes: 8 },
-]
-
 /* ================= 컴포넌트 ================= */
 
 export default function Step5PlaceList({ onStatusLoaded }: Step3PlaceListProps) {
@@ -217,8 +207,9 @@ export default function Step5PlaceList({ onStatusLoaded }: Step3PlaceListProps) 
   const [showVoteModal, setShowVoteModal] = useState(false)
 
   const [, setMiddlePoint] = useState<MiddlePoint | null>(null)
-  const [placeSource, setPlaceSource] =
-    useState<Omit<RecommendedPlace, 'icon'>[]>(rawPlaces)
+  const [placeSource, setPlaceSource] = useState<
+    Omit<RecommendedPlace, 'icon'>[]
+  >([])
   const [isLoadingPlaces, setIsLoadingPlaces] = useState(false)
   const [isConfirming, setIsConfirming] = useState(false)
   const [voteData, setVoteData] = useState<VoteData | null>(null)
@@ -258,18 +249,16 @@ export default function Step5PlaceList({ onStatusLoaded }: Step3PlaceListProps) 
         })
       }
 
-      if (apiPlaces.length >= 6) {
-        const parsedPlaces = apiPlaces
-          .map(parseApiPlace)
-          .filter(
-            (place): place is Omit<RecommendedPlace, 'icon'> => place !== null
-          )
-        if (parsedPlaces.length >= 6) {
-          setPlaceSource(parsedPlaces.slice(0, 6))
-          setHasInitiallyLoaded(true)
-        }
-      }
+      const parsedPlaces = apiPlaces
+        .map(parseApiPlace)
+        .filter(
+          (place): place is Omit<RecommendedPlace, 'icon'> => place !== null
+        )
+      setPlaceSource(parsedPlaces.slice(0, 6))
+      setHasInitiallyLoaded(true)
     } catch {
+      setPlaceSource([])
+      setHasInitiallyLoaded(true)
       try {
         const res = await axios.get(
           `${API_BASE_URL}/v1/meetings/${meetingUuid}/middle-point`,
@@ -578,7 +567,8 @@ export default function Step5PlaceList({ onStatusLoaded }: Step3PlaceListProps) 
     voteButtonLabel = '새 추천 장소! 투표 갱신'
   else if (voteData?.options?.length) voteButtonLabel = '투표하기'
 
-  const isVoteDisabled = isCreatingVote || (!isHost && !hasVote)
+  const isVoteDisabled =
+    isCreatingVote || recommendedPlaces.length === 0 || (!isHost && !hasVote)
 
   let confirmLabel = '추천 장소 확정'
   if (isConfirming) confirmLabel = '확정 중...'
@@ -653,6 +643,12 @@ export default function Step5PlaceList({ onStatusLoaded }: Step3PlaceListProps) 
           <div className="flex items-center justify-center rounded-lg border border-[var(--border)] py-10">
             <span className="text-sm text-[var(--text-subtle)]">
               추천 장소를 찾고 있어요...
+            </span>
+          </div>
+        ) : recommendedPlaces.length === 0 ? (
+          <div className="flex items-center justify-center rounded-lg border border-[var(--border)] py-10">
+            <span className="text-sm text-[var(--text-subtle)]">
+              추천 장소 데이터가 없어요. 잠시 후 다시 시도해주세요.
             </span>
           </div>
         ) : (

--- a/frontend/src/components/meeting/Step3/Step3PlaceList.tsx
+++ b/frontend/src/components/meeting/Step3/Step3PlaceList.tsx
@@ -103,7 +103,8 @@ interface Step3PlaceListProps {
 
 /* ================= API BASE ================= */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080/api'
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080/api'
 
 /* ================= 유틸 ================= */
 
@@ -143,7 +144,12 @@ function toNumber(value: unknown): number | undefined {
 }
 
 function isPlaceCategory(value: unknown): value is PlaceCategory {
-  return value === 'cafe' || value === 'restaurant' || value === 'culture' || value === 'tour'
+  return (
+    value === 'cafe' ||
+    value === 'restaurant' ||
+    value === 'culture' ||
+    value === 'tour'
+  )
 }
 
 function parseApiPlace(place: unknown): Omit<RecommendedPlace, 'icon'> | null {
@@ -157,7 +163,9 @@ function parseApiPlace(place: unknown): Omit<RecommendedPlace, 'icon'> | null {
   return {
     id: placeId,
     name: placeName,
-    category: isPlaceCategory(place.category) ? place.category : 'restaurant',
+    category: isPlaceCategory(place.category)
+      ? place.category
+      : 'restaurant',
     stationName: toString(place.stationName) || '중간지점',
     walkingMinutes: toNumber(place.walkingMinutes) ?? 0,
     placeId,
@@ -200,11 +208,9 @@ const rawPlaces: Omit<RecommendedPlace, 'icon'>[] = [
 
 /* ================= 컴포넌트 ================= */
 
-export default function Step5PlaceList({
-                                        onStatusLoaded,
-                                      }: Step3PlaceListProps) {
-const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
-  const [mapRefreshKey, setMapRefreshKey] = useState(0)  // 지도 갱신 트리거
+export default function Step5PlaceList({ onStatusLoaded }: Step3PlaceListProps) {
+  const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
+  const [mapRefreshKey, setMapRefreshKey] = useState(0)
   const router = useRouter()
   const searchParams = useSearchParams()
   const meetingUuid = searchParams.get('meetingUuid')
@@ -213,7 +219,8 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
   const [showVoteModal, setShowVoteModal] = useState(false)
 
   const [, setMiddlePoint] = useState<MiddlePoint | null>(null)
-  const [placeSource, setPlaceSource] = useState<Omit<RecommendedPlace, 'icon'>[]>(rawPlaces)
+  const [placeSource, setPlaceSource] =
+    useState<Omit<RecommendedPlace, 'icon'>[]>(rawPlaces)
   const [isLoadingPlaces, setIsLoadingPlaces] = useState(false)
   const [isConfirming, setIsConfirming] = useState(false)
   const [voteData, setVoteData] = useState<VoteData | null>(null)
@@ -224,34 +231,27 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
   const { user } = useUser()
   const stompClientRef = useRef<Client | null>(null)
 
-  const myParticipant = participants.find(
-    p => p.userId === user?.id
-  )
+  const myParticipant = participants.find((p) => p.userId === user?.id)
   const myNickname = myParticipant?.nickName ?? '나'
 
-  /* ================= 모임장 여부 체크 ================= */
-
-  const isHost = organizerId != null && user?.id != null && organizerId === user.id
+  const isHost =
+    organizerId != null && user?.id != null && organizerId === user.id
   const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false)
 
-  /* ================= 추천장소 + 중간지점 통합 API ================= */
+  /* ================= 추천장소 + 중간지점 ================= */
 
   const fetchPlacesAndMidpoint = useCallback(async () => {
     if (!meetingUuid || !meetingPurpose) return
-
     setIsLoadingPlaces(true)
-
     try {
       const res = await axios.get(
         `${API_BASE_URL}/v1/meetings/${meetingUuid}/places?purpose=${meetingPurpose}&limit=6`,
         { withCredentials: true }
       )
-
       const data = res.data?.data
       const apiPlaces: unknown[] = Array.isArray(data?.places) ? data.places : []
       const apiMidpoint = data?.midpoint
 
-      // 중간지점 설정
       if (apiMidpoint?.latitude && apiMidpoint?.longitude) {
         setMiddlePoint({
           lat: apiMidpoint.latitude,
@@ -260,19 +260,18 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
         })
       }
 
-      // 추천장소 설정 (6개 이상일 때만 교체)
       if (apiPlaces.length >= 6) {
         const parsedPlaces = apiPlaces
           .map(parseApiPlace)
-          .filter((place): place is Omit<RecommendedPlace, 'icon'> => place !== null)
-
+          .filter(
+            (place): place is Omit<RecommendedPlace, 'icon'> => place !== null
+          )
         if (parsedPlaces.length >= 6) {
           setPlaceSource(parsedPlaces.slice(0, 6))
           setHasInitiallyLoaded(true)
         }
       }
     } catch {
-      // places API 실패 시 기존 middle-point API 폴백
       try {
         const res = await axios.get(
           `${API_BASE_URL}/v1/meetings/${meetingUuid}/middle-point`,
@@ -287,7 +286,6 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
     }
   }, [meetingUuid, meetingPurpose])
 
-  // fetchPlacesAndMidpoint를 ref로 관리하여 WebSocket 콜백에서 최신값 참조
   const fetchPlacesAndMidpointRef = useRef(fetchPlacesAndMidpoint)
   useEffect(() => {
     fetchPlacesAndMidpointRef.current = fetchPlacesAndMidpoint
@@ -297,9 +295,8 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
     fetchPlacesAndMidpoint()
   }, [fetchPlacesAndMidpoint])
 
-  /* ================= WebSocket 연결 ================= */
+  /* ================= WebSocket ================= */
 
-  // voteData를 ref로 관리하여 WebSocket 콜백에서 최신값 참조
   const voteDataRef = useRef(voteData)
   useEffect(() => {
     voteDataRef.current = voteData
@@ -307,11 +304,9 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
 
   useEffect(() => {
     if (!meetingUuid) return
-
     const client = new Client({
       webSocketFactory: () => new SockJS(`${API_BASE_URL}/ws`),
       onConnect: () => {
-        // 1. 투표 업데이트 구독
         if (voteData?.voteId) {
           client.subscribe(`/topic/votes/${voteData.voteId}`, (message) => {
             try {
@@ -320,74 +315,45 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
                 setVoteData(result)
                 setIsNewPlaceAvailable(false)
               }
-            } catch (error) {
-              console.error('WebSocket 메시지 처리 실패:', error)
-            }
+            } catch {}
           })
         }
 
-        // 2. 투표 생성/삭제 구독
         client.subscribe(`/topic/votes/meeting/${meetingUuid}`, (message) => {
           try {
             const result = JSON.parse(message.body)
-
-            // 투표 삭제 알림 처리 (장소 변경으로 인한 자동 삭제)
             if (result.type === 'VOTE_DELETED') {
               setVoteData(null)
-              console.log('투표가 삭제되었습니다 (장소 변경)')
               return
             }
-
-            // 투표 생성/업데이트 처리
             if (result.voteId && result.options) {
               setVoteData(result)
               setIsNewPlaceAvailable(false)
             }
-          } catch (error) {
-            console.error('투표 WebSocket 처리 실패:', error)
-          }
+          } catch {}
         })
 
-        // 3. 장소 캐시 무효화 알림 구독
-        client.subscribe(`/topic/meeting/${meetingUuid}/places`, (message) => {
-          try {
-            const notification = JSON.parse(message.body)
-            if (notification.type === 'CACHE_INVALIDATED') {
-              // 항상 새 추천 장소 불러오기 (ref 사용으로 최신 함수 참조)
-              fetchPlacesAndMidpointRef.current()
-
-              // 지도 경로도 갱신
-              setMapRefreshKey(prev => prev + 1)
-
-              // 투표 진행 중이면 추가로 알림 표시
-              if (voteDataRef.current) {
-                setIsNewPlaceAvailable(true)
-              }
-            }
-          } catch (error) {
-            console.error('장소 알림 WebSocket 처리 실패:', error)
+        client.subscribe(`/topic/meeting/${meetingUuid}/places`, () => {
+          fetchPlacesAndMidpointRef.current()
+          setMapRefreshKey((p) => p + 1)
+          if (voteDataRef.current) {
+            setIsNewPlaceAvailable(true)
           }
         })
-      },
-      onStompError: (frame) => {
-        console.error('STOMP error:', frame)
       },
     })
-
     client.activate()
     stompClientRef.current = client
-
     return () => {
       client.deactivate()
       stompClientRef.current = null
     }
   }, [voteData?.voteId, meetingUuid])
 
-  /* ================= 참여자 API ================= */
+  /* ================= 참여자 ================= */
 
   useEffect(() => {
     if (!meetingUuid || !user?.id) return
-
     axios
       .get(`${API_BASE_URL}/v1/meetings/${meetingUuid}`, {
         withCredentials: true,
@@ -397,25 +363,17 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
         const rawParticipants: Participant[] = data?.participants ?? []
         const sorted = sortParticipants(rawParticipants, user?.id)
         setParticipants(sorted)
-
         const organizerIdValue = Number(data?.organizerId ?? 0)
         setOrganizerId(organizerIdValue || null)
-
-        // 모임 목적 저장
         setMeetingPurpose(data?.purpose || 'DINING')
-
-        // ⭐ 모임 상태를 부모 컴포넌트에 전달
         if (onStatusLoaded && data?.status) {
           onStatusLoaded(data.status)
         }
       })
-      .catch((err) => {
-        console.error('Meeting API Error:', err)
-        setParticipants([])
-      })
+      .catch(() => setParticipants([]))
   }, [meetingUuid, user?.id, onStatusLoaded])
 
-  /* ================= 추천 장소 (아이콘 주입) ================= */
+  /* ================= 추천 장소 ================= */
 
   const recommendedPlaces: RecommendedPlace[] = useMemo(
     () =>
@@ -426,93 +384,75 @@ const [isNewPlaceAvailable, setIsNewPlaceAvailable] = useState(false)
     [placeSource]
   )
 
-  // 추천장소 구성 변경 감지용 시그니처
-  const placeSignature = useMemo(() => {
-    return recommendedPlaces
-      .map(p => p.name)
-      .sort()
-      .join('|')
-  }, [recommendedPlaces])
+  const placeSignature = useMemo(
+    () => recommendedPlaces.map((p) => p.name).sort().join('|'),
+    [recommendedPlaces]
+  )
 
-useEffect(() => {
-  if (!placeSignature || !meetingUuid || isLoadingPlaces || !hasInitiallyLoaded) return;
+  useEffect(() => {
+    if (!placeSignature || !meetingUuid || isLoadingPlaces || !hasInitiallyLoaded)
+      return
+    const storageKey = `place-signature-${meetingUuid}`
+    const prevSignature = localStorage.getItem(storageKey)
+    if (prevSignature && prevSignature !== placeSignature) {
+      setIsNewPlaceAvailable(true)
+    }
+    localStorage.setItem(storageKey, placeSignature)
+  }, [placeSignature, meetingUuid, isLoadingPlaces, hasInitiallyLoaded])
 
-  const storageKey = `place-signature-${meetingUuid}`;
-  const prevSignature = localStorage.getItem(storageKey);
-
-  if (prevSignature && prevSignature !== placeSignature) {
-    setIsNewPlaceAvailable(true);
-  }
-
-  localStorage.setItem(storageKey, placeSignature);
-}, [placeSignature, meetingUuid, isLoadingPlaces, hasInitiallyLoaded]);
-
-  /* ================= 투표 API ================= */
+  /* ================= 투표 ================= */
 
   const fetchVote = useCallback(async (): Promise<VoteData | null> => {
-    if (!meetingUuid) return null;
-
+    if (!meetingUuid) return null
     try {
-      const res = await axios.get(`${API_BASE_URL}/v1/votes/meeting/${meetingUuid}`, {
-        withCredentials: true,
-        validateStatus: (status) => status < 500 // 404도 then으로 처리
-      });
-
-      if (res.status === 404) return null; // 투표가 없으면 null 반환
-      return res.data?.data ?? null;
+      const res = await axios.get(
+        `${API_BASE_URL}/v1/votes/meeting/${meetingUuid}`,
+        { withCredentials: true, validateStatus: (s) => s < 500 }
+      )
+      if (res.status === 404) return null
+      return res.data?.data ?? null
     } catch {
-      return null; // 네트워크 오류만 무시
+      return null
     }
-  }, [meetingUuid]);
+  }, [meetingUuid])
 
   useEffect(() => {
     if (!meetingUuid) return
-
     let cancelled = false
-
     const initFetchVote = async () => {
       const fetchedVote = await fetchVote()
-      if (!cancelled && fetchedVote) {
-        setVoteData(fetchedVote)
-      }
+      if (!cancelled && fetchedVote) setVoteData(fetchedVote)
     }
-
     initFetchVote()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [meetingUuid, fetchVote])
 
- const createVote = async () => {
-   if (!meetingUuid || !isHost) {
-     alert('모임장만 투표를 생성할 수 있습니다.')
-     return
-   }
-
-   setIsCreatingVote(true)
-   try {
-     const options = recommendedPlaces.map(p => p.name)
-
-     // 백엔드 호출: 기존 투표 삭제 + 새 투표 생성이 서버에서 한 번에 일어남
-     await axios.post(
-       `${API_BASE_URL}/v1/votes/meeting/${meetingUuid}`,
-       { options },
-       { withCredentials: true }
-     )
-
-     const storageKey = `place-signature-${meetingUuid}`;
-     localStorage.setItem(storageKey, placeSignature);
-     setIsNewPlaceAvailable(false);
-     setShowVoteModal(true);
-   } catch (error) {
-     console.error('투표 생성 실패:', error)
-     alert('투표 생성에 실패했습니다.')
-   } finally {
-     setIsCreatingVote(false)
-   }
- }
+  const createVote = async () => {
+    if (!meetingUuid || !isHost) {
+      alert('모임장만 투표를 생성할 수 있습니다.')
+      return
+    }
+    setIsCreatingVote(true)
+    try {
+      const options = recommendedPlaces.map((p) => p.name)
+      await axios.post(
+        `${API_BASE_URL}/v1/votes/meeting/${meetingUuid}`,
+        { options },
+        { withCredentials: true }
+      )
+      const storageKey = `place-signature-${meetingUuid}`
+      localStorage.setItem(storageKey, placeSignature)
+      setIsNewPlaceAvailable(false)
+      setShowVoteModal(true)
+    } finally {
+      setIsCreatingVote(false)
+    }
+  }
 
   const submitVote = async (optionId: number) => {
     if (!voteData) return
-
     setIsVoting(true)
     try {
       await axios.post(
@@ -520,78 +460,60 @@ useEffect(() => {
         { optionId },
         { withCredentials: true }
       )
-
-      const myParticipantId = participants.find(p => p.userId === user?.id)?.participantId
+      const myParticipantId = participants.find(
+        (p) => p.userId === user?.id
+      )?.participantId
       if (myParticipantId) {
-        setVoteData(prev => {
+        setVoteData((prev) => {
           if (!prev) return prev
-
           return {
             ...prev,
-            options: prev.options.map(opt => {
-              const filteredVoters = opt.voters.filter(v => v.participantId !== myParticipantId)
-
+            options: prev.options.map((opt) => {
+              const filtered = opt.voters.filter(
+                (v) => v.participantId !== myParticipantId
+              )
               if (opt.optionId === optionId) {
                 return {
                   ...opt,
-                  voteCount: filteredVoters.length + 1,
-                  voters: [...filteredVoters, {
-                    participantId: myParticipantId,
-                    nickname: myNickname,
-                  }]
+                  voteCount: filtered.length + 1,
+                  voters: [
+                    ...filtered,
+                    { participantId: myParticipantId, nickname: myNickname },
+                  ],
                 }
               }
-
-              return {
-                ...opt,
-                voteCount: filteredVoters.length,
-                voters: filteredVoters
-              }
-            })
+              return { ...opt, voteCount: filtered.length, voters: filtered }
+            }),
           }
         })
       }
-
       setShowVoteModal(false)
-    } catch (error) {
-      console.error('투표 참여 실패:', error)
-      alert('투표에 실패했습니다.')
     } finally {
       setIsVoting(false)
     }
   }
 
   const handleVoteButtonClick = async () => {
-    if (!meetingUuid) return;
-
-    const hasVote = Boolean(voteData?.options?.length);
-
-    // 1. 투표 시작하기 또는 갱신 (모임장 전용)
+    if (!meetingUuid) return
+    const hasVote = Boolean(voteData?.options?.length)
     if (isHost && (!hasVote || isNewPlaceAvailable)) {
-      await createVote();
-      setIsNewPlaceAvailable(false);
-      return;
+      await createVote()
+      setIsNewPlaceAvailable(false)
+      return
     }
+    if (hasVote) setShowVoteModal(true)
+  }
 
-    // 2. 투표하기
-    if (hasVote) {
-      setShowVoteModal(true);
-    }
-  };
-
-  /* ================= 장소 확정 핸들러 ================= */
+  /* ================= 확정 ================= */
 
   const handleConfirmPlace = async () => {
     if (!selectedPlace || !meetingUuid) return
-
     if (!isHost) {
       alert('모임장만 장소를 확정할 수 있습니다.')
       return
     }
-
     const selected = recommendedPlaces.find((p) => p.id === selectedPlace)
     if (!selected) return
-
     setIsConfirming(true)
     try {
       await axios.post(
@@ -614,164 +536,154 @@ useEffect(() => {
         { withCredentials: true }
       )
       router.push(`/meetings/${meetingUuid}/complete`)
-    } catch (err) {
-      console.error('장소 확정 실패:', err)
-      alert('장소 확정에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setIsConfirming(false)
     }
   }
 
-  /* ================= 투표 데이터 계산 ================= */
+  /* ================= 계산 ================= */
 
   const placeVoteMap = useMemo(() => {
     if (!voteData) return new Map()
-
     const map = new Map<string, VoteOption>()
-    voteData.options.forEach(option => {
-      const place = recommendedPlaces.find(p => p.name === option.content)
-      if (place) {
-        map.set(place.id, option)
-      }
+    voteData.options.forEach((option) => {
+      const place = recommendedPlaces.find((p) => p.name === option.content)
+      if (place) map.set(place.id, option)
     })
     return map
   }, [voteData, recommendedPlaces])
 
   const myVotedOptionId = useMemo(() => {
     if (!voteData || !user?.id) return null
-
-    const myParticipantId = participants.find(p => p.userId === user?.id)?.participantId
+    const myParticipantId = participants.find(
+      (p) => p.userId === user?.id
+    )?.participantId
     if (!myParticipantId) return null
-
-    const votedOption = voteData.options.find(opt =>
-      opt.voters.some(v => v.participantId === myParticipantId)
+    const voted = voteData.options.find((opt) =>
+      opt.voters.some((v) => v.participantId === myParticipantId)
     )
-
-    return votedOption?.optionId || null
+    return voted?.optionId || null
   }, [voteData, user?.id, participants])
 
-  const totalVotes = voteData?.options.reduce((sum, opt) => sum + opt.voteCount, 0) || 0
-  const maxVotes = voteData ? Math.max(...voteData.options.map(opt => opt.voteCount)) : 0
+  const totalVotes =
+    voteData?.options.reduce((sum, opt) => sum + opt.voteCount, 0) || 0
+  const maxVotes = voteData
+    ? Math.max(...voteData.options.map((opt) => opt.voteCount))
+    : 0
 
+  const hasVote = Boolean(voteData?.options?.length)
+  let voteButtonLabel = '투표 대기 중'
+  if (isCreatingVote) voteButtonLabel = '생성 중...'
+  else if (isHost && !voteData?.options?.length)
+    voteButtonLabel = '투표 시작하기'
+  else if (isHost && isNewPlaceAvailable)
+    voteButtonLabel = '새 추천 장소! 투표 갱신'
+  else if (voteData?.options?.length) voteButtonLabel = '투표하기'
 
-  const hasVote = Boolean(voteData?.options?.length);
-  let voteButtonLabel = '투표 대기 중';
+  const isVoteDisabled = isCreatingVote || (!isHost && !hasVote)
 
-    if (isCreatingVote) {
-      voteButtonLabel = '생성 중...';
-    }
-    // 1. 투표가 아예 없는 완전 초기 상태 (모임장용)
-    else if (isHost && !voteData?.options?.length) {
-      voteButtonLabel = '투표 시작하기';
-    }
-    // 2. 투표가 있는데, 그 사이에 장소까지 바뀌었을 때 (모임장)
-    else if (isHost && isNewPlaceAvailable) {
-      voteButtonLabel = '새 추천 장소! 투표 갱신';
-    }
-    // 3. 투표가 있고 장소 변경도 없을 때
-    else if (voteData?.options?.length) {
-      voteButtonLabel = '투표하기';
-    }
-    const isVoteDisabled =
-      isCreatingVote ||
-      (!isHost && !hasVote); // 투표가 없는데 일반 참여자일 때
-    let confirmLabel = '추천 장소 확정'
-    if (isConfirming) {
-    confirmLabel = '확정 중...'
-    } else if (!isHost) {
-    confirmLabel = '모임장만 확정할 수 있습니다'
-    }
+  let confirmLabel = '추천 장소 확정'
+  if (isConfirming) confirmLabel = '확정 중...'
+  else if (!isHost) confirmLabel = '모임장만 확정할 수 있습니다'
 
   return (
-    <div className="space-y-4">
-      {/* ================= 지도 (참여자 경로 시각화) ================= */}
+    <div className="relative">
+      {/* ================= 지도: 배경 ================= */}
+      {/* 1/30[유리] - 지도 배경화 및 콘텐츠 오버레이 */}
       {meetingUuid && (
-        <Card className="overflow-hidden border border-[var(--border)] bg-[var(--bg)]">
-          <CardContent className="p-0">
-            <div className="h-72">
-              <Step4Map meetingUuid={meetingUuid} refreshKey={mapRefreshKey} minHeight={288} />
+        <div className="relative h-[60vh] min-h-[360px]">
+          <Step4Map
+            meetingUuid={meetingUuid}
+            refreshKey={mapRefreshKey}
+            minHeight={360}
+          />
+
+          {/* 투표 중앙 CTA */}
+          {/* 1/30[유리] - 투표 가능 시 지도 중앙 CTA(danger) */}
+          {hasVote && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <Button
+                type="button"
+                onClick={handleVoteButtonClick}
+                disabled={isVoteDisabled}
+                className="pointer-events-auto bg-[var(--danger)] text-white py-6 px-6 text-base font-semibold"
+              >
+                투표 참여하기
+              </Button>
             </div>
-          </CardContent>
-        </Card>
+          )}
+        </div>
       )}
 
-      {/* 투표 현황 배너 */}
-      {voteData && totalVotes > 0 && (
-        <Card className="border border-[var(--border)] bg-[var(--bg-soft)]">
-          <CardContent className="flex items-center justify-between p-4">
-            {/* 왼쪽: 투표 현황 */}
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--primary)]">
-                <TrendingUp className="h-5 w-5 text-[var(--primary-foreground)]" />
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold text-[var(--text)]">투표 진행 중</h3>
-                <p className="text-xs text-[var(--text-subtle)]">
-                  총 {totalVotes}명이 투표했습니다
-                </p>
-              </div>
-            </div>
-
-          </CardContent>
-        </Card>
+      {/* Toast */}
+      {/* 1/30[유리] - 지도 위 고정 배너 제거 → Toast 전환(danger) */}
+      {isNewPlaceAvailable && (
+        <div className="fixed left-1/2 top-4 z-50 -translate-x-1/2">
+          <button
+            type="button"
+            onClick={() => setShowVoteModal(true)}
+            className="flex items-center gap-2 rounded-full bg-[var(--danger-soft)] px-4 py-2 text-sm font-medium text-[var(--danger)]"
+          >
+            <AlertTriangle className="h-4 w-4" />
+            새로운 추천 장소가 있어요 · 투표하기
+          </button>
+        </div>
       )}
 
-      {/* 추천 장소 */}
-      <section className="space-y-3">
-        <div className="flex items-center justify-between">
+      {/* ================= 추천 장소 ================= */}
+      <section className="relative z-10 mx-auto max-w-xl bg-[var(--bg)] p-4">
+        <div className="mb-3 flex items-center justify-between">
           <div>
-            <h2 className="text-base font-semibold text-[var(--text)]">추천장소 선택</h2>
+            <h2 className="text-base font-semibold text-[var(--text)]">
+              추천장소 선택
+            </h2>
             <p className="text-xs text-[var(--text-subtle)]">
-              중간지점 기준으로 추천된 장소입니다.
+              중간지점 기준 추천
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            {isNewPlaceAvailable && (
-              <div className="flex items-center gap-1.5 text-amber-600">
-                <AlertTriangle className="h-4 w-4" />
-                <span className="text-sm font-medium">장소 변경됨</span>
-              </div>
-            )}
-            <Button
-              type="button"
-              disabled={isVoteDisabled}
-              onClick={handleVoteButtonClick}
-              className="rounded-lg bg-[var(--primary)] text-[var(--primary-foreground)] disabled:opacity-40"
-            >
-              {voteButtonLabel}
-            </Button>
-          </div>
+          <Button
+            type="button"
+            disabled={isVoteDisabled}
+            onClick={handleVoteButtonClick}
+            className="bg-[var(--danger)] text-white disabled:opacity-40"
+          >
+            {voteButtonLabel}
+          </Button>
         </div>
 
         {isLoadingPlaces ? (
-          <div className="flex items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--bg-soft)] py-10">
-            <span className="text-sm text-[var(--text-subtle)]">추천 장소를 찾고 있어요...</span>
+          <div className="flex items-center justify-center rounded-lg border border-[var(--border)] py-10">
+            <span className="text-sm text-[var(--text-subtle)]">
+              추천 장소를 찾고 있어요...
+            </span>
           </div>
         ) : (
-          <div className="grid gap-2 grid-cols-1 md:grid-cols-2">
+          <div className="grid grid-cols-2 gap-2">
             {recommendedPlaces.map((place) => {
               const Icon = place.icon
               const selected = selectedPlace === place.id
               const voteOption = placeVoteMap.get(place.id)
               const hasVotes = Boolean(voteOption && voteOption.voteCount > 0)
-              const isTopChoice = Boolean(voteOption && voteOption.voteCount === maxVotes && maxVotes > 0)
-              const votePercentage = totalVotes > 0 && voteOption
-                ? (voteOption.voteCount / totalVotes) * 100
-                : 0
+              const isTopChoice = Boolean(
+                voteOption &&
+                  voteOption.voteCount === maxVotes &&
+                  maxVotes > 0
+              )
+              const votePercentage =
+                totalVotes > 0 && voteOption
+                  ? (voteOption.voteCount / totalVotes) * 100
+                  : 0
 
-              let cardClass =
-                'flex w-full items-center gap-3 rounded-xl px-4 py-3 border-2 relative overflow-hidden'
-              if (selected) {
-                cardClass += ' border-[var(--primary)] bg-[var(--bg-soft)]'
-              } else {
-                cardClass += ' border-[var(--border)] bg-[var(--bg)]'
-              }
+              let cls =
+                'relative flex items-center gap-3 rounded-lg border p-3'
+              if (selected) cls += ' border-[var(--danger)]'
+              else cls += ' border-[var(--border)]'
 
               return (
                 <button
                   key={place.id}
                   onClick={() => setSelectedPlace(place.id)}
-                  className={cardClass}
+                  className={cls}
                 >
                   {hasVotes && (
                     <div
@@ -779,40 +691,36 @@ useEffect(() => {
                       style={{
                         width: `${votePercentage}%`,
                         backgroundColor: 'var(--neutral-soft)',
-                        opacity: 0.6,
+                        opacity: 0.5,
                       }}
                     />
                   )}
-
-                  <div className="relative flex h-12 w-12 items-center justify-center rounded-lg bg-[var(--neutral-soft)]">
-                    <Icon className="h-8 w-8 text-[var(--primary)]" />
+                  <div className="relative flex h-10 w-10 items-center justify-center rounded-md bg-[var(--neutral-soft)]">
+                    <Icon className="h-6 w-6 text-[var(--danger)]" />
                   </div>
-                  <div className="flex-1 text-left relative">
-                    <p className="text-sm font-semibold text-[var(--text)]">{place.name}</p>
-                    <p className="text-xs text-[var(--text-subtle)]">
-                      {place.stationName} 도보 {place.walkingMinutes}분
+                  <div className="relative flex-1 text-left">
+                    <p className="text-sm font-semibold text-[var(--text)]">
+                      {place.name}
                     </p>
-
+                    <p className="text-xs text-[var(--text-subtle)]">
+                      {place.stationName} · {place.walkingMinutes}분
+                    </p>
                     {hasVotes && voteOption && (
                       <div className="mt-1 flex items-center gap-2">
-                        <div className="flex items-center gap-1">
-                          <Users className="h-3 w-3 text-[var(--primary)]" />
-                          <span className="text-xs font-semibold text-[var(--primary)]">
-                            {voteOption.voteCount}표
-                          </span>
-                        </div>
+                        <span className="text-xs font-semibold text-[var(--danger)]">
+                          {voteOption.voteCount}표
+                        </span>
                         {isTopChoice && (
-                          <span className="rounded-full bg-[var(--primary)] px-1.5 py-0.5 text-[9px] font-semibold text-[var(--primary-foreground)]">
+                          <span className="rounded-full bg-[var(--danger)] px-1.5 py-0.5 text-[9px] font-semibold text-white">
                             1위
                           </span>
                         )}
-                        <span className="text-[9px] text-[var(--text-subtle)]">
-                          {votePercentage.toFixed(0)}%
-                        </span>
                       </div>
                     )}
                   </div>
-                  {selected && <CheckCircle className="h-5 w-5 text-[var(--primary)] relative" />}
+                  {selected && (
+                    <CheckCircle className="relative h-5 w-5 text-[var(--danger)]" />
+                  )}
                 </button>
               )
             })}
@@ -820,7 +728,7 @@ useEffect(() => {
         )}
       </section>
 
-      {/* 투표 모달 */}
+      {/* ================= Drawer(기존) ================= */}
       <WireframeModal
         open={showVoteModal}
         title="추천장소 투표"
@@ -831,26 +739,31 @@ useEffect(() => {
             <>
               <div className="mb-4 text-center">
                 <p className="text-sm text-[var(--text-subtle)]">
-                  총 {totalVotes}표 · {myVotedOptionId ? '투표 완료' : '투표해주세요'}
+                  총 {totalVotes}표 ·{' '}
+                  {myVotedOptionId ? '투표 완료' : '투표해주세요'}
                 </p>
               </div>
 
               <ScrollArea className="max-h-80 pr-1">
                 <div className="space-y-2">
                   {voteData.options.map((option) => {
-                    const place = recommendedPlaces.find(p => p.name === option.content)
+                    const place = recommendedPlaces.find(
+                      (p) => p.name === option.content
+                    )
                     const Icon = place?.icon || Coffee
                     const isMyVote = option.optionId === myVotedOptionId
-                    const votePercentage = totalVotes > 0 ? (option.voteCount / totalVotes) * 100 : 0
-                    const isTopChoice = option.voteCount === maxVotes && maxVotes > 0
+                    const votePercentage =
+                      totalVotes > 0
+                        ? (option.voteCount / totalVotes) * 100
+                        : 0
+                    const isTopChoice =
+                      option.voteCount === maxVotes && maxVotes > 0
 
                     let optionClass =
-                      'relative w-full overflow-hidden rounded-xl border-2 p-3 text-left'
-                    if (isMyVote) {
-                      optionClass += ' border-[var(--primary)] bg-[var(--bg-soft)]'
-                    } else {
-                      optionClass += ' border-[var(--border)] bg-[var(--bg)]'
-                    }
+                      'relative w-full overflow-hidden rounded-lg border p-3 text-left'
+                    if (isMyVote)
+                      optionClass += ' border-[var(--danger)]'
+                    else optionClass += ' border-[var(--border)]'
 
                     return (
                       <button
@@ -867,58 +780,24 @@ useEffect(() => {
                             opacity: 0.5,
                           }}
                         />
-
                         <div className="relative flex items-center gap-3">
-                          <div
-                            className="flex h-10 w-10 items-center justify-center rounded-lg"
-                            style={{
-                              backgroundColor: isMyVote
-                                ? 'var(--primary)'
-                                : 'var(--neutral-soft)',
-                            }}
-                          >
-                            <Icon
-                              className="h-6 w-6"
-                              style={{
-                                color: isMyVote
-                                  ? 'var(--primary-foreground)'
-                                  : 'var(--primary)',
-                              }}
-                            />
+                          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[var(--neutral-soft)]">
+                            <Icon className="h-6 w-6 text-[var(--danger)]" />
                           </div>
-
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2 mb-1">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
                               <p className="text-sm font-semibold text-[var(--text)]">
                                 {option.content}
                               </p>
                               {isTopChoice && option.voteCount > 0 && (
-                                <span className="rounded-full bg-[var(--primary)] px-1.5 py-0.5 text-[9px] font-semibold text-[var(--primary-foreground)]">
+                                <span className="rounded-full bg-[var(--danger)] px-1.5 py-0.5 text-[9px] font-semibold text-white">
                                   1위
                                 </span>
                               )}
                             </div>
-
-                            {option.voters.length > 0 && (
-                              <div className="flex flex-wrap items-center gap-1.5">
-                                <span className="text-xs font-semibold text-[var(--primary)]">
-                                  {option.voteCount}표
-                                </span>
-                                <span className="text-xs text-[var(--text-subtle)]">·</span>
-                                {option.voters.map((voter) => (
-                                  <span
-                                    key={voter.participantId}
-                                    className="rounded-full bg-[var(--neutral-soft)] px-2 py-0.5 text-[9px] font-medium text-[var(--text)]"
-                                  >
-                                    {voter.nickname}
-                                  </span>
-                                ))}
-                              </div>
-                            )}
                           </div>
-
                           {isMyVote && (
-                            <CheckCircle className="h-5 w-5 text-[var(--primary)]" />
+                            <CheckCircle className="h-5 w-5 text-[var(--danger)]" />
                           )}
                         </div>
                       </button>
@@ -927,57 +806,20 @@ useEffect(() => {
                 </div>
               </ScrollArea>
             </>
-          ) : (
-            <div className="space-y-2">
-              {recommendedPlaces.map((place) => {
-                const Icon = place.icon
-                const selected = selectedPlace === place.id
-
-                let optionClass =
-                  'flex w-full items-center gap-3 rounded-xl px-4 py-3 border-2'
-                if (selected) {
-                  optionClass += ' border-[var(--primary)] bg-[var(--bg-soft)]'
-                } else {
-                  optionClass += ' border-[var(--border)] bg-[var(--bg)]'
-                }
-
-                return (
-                  <button
-                    key={`vote-${place.id}`}
-                    onClick={() => {
-                      setSelectedPlace(place.id)
-                      setShowVoteModal(false)
-                    }}
-                    className={optionClass}
-                  >
-                    <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-[var(--neutral-soft)]">
-                      <Icon className="h-8 w-8 text-[var(--primary)]" />
-                    </div>
-                    <div className="flex-1 text-left">
-                      <p className="text-sm font-semibold text-[var(--text)]">{place.name}</p>
-                      <p className="text-xs text-[var(--text-subtle)]">
-                        {place.stationName} 도보 {place.walkingMinutes}분
-                      </p>
-                    </div>
-                    {selected && (
-                      <CheckCircle className="h-5 w-5 text-[var(--primary)]" />
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          )}
+          ) : null}
         </div>
       </WireframeModal>
 
-      {/* 확정 버튼 */}
-      <Button
-        disabled={!selectedPlace || isConfirming || !isHost}
-        onClick={handleConfirmPlace}
-        className="w-full rounded-2xl bg-[var(--primary)] text-[var(--primary-foreground)] py-4 text-base font-semibold disabled:opacity-40"
-      >
-        {confirmLabel}
-      </Button>
+      {/* ================= 확정 CTA ================= */}
+      <div className="sticky bottom-0 z-20 bg-[var(--bg)] p-4">
+        <Button
+          disabled={!selectedPlace || isConfirming || !isHost}
+          onClick={handleConfirmPlace}
+          className="w-full bg-[var(--danger)] text-white py-6 text-base font-semibold disabled:opacity-40"
+        >
+          {confirmLabel}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/meeting/Step3/Step3PlaceList.tsx
+++ b/frontend/src/components/meeting/Step3/Step3PlaceList.tsx
@@ -34,14 +34,12 @@ import {
   Mountain,
   TreePalm,
   Building2,
-  Users,
-  TrendingUp,
   AlertTriangle,
   type LucideIcon,
 } from 'lucide-react'
 
 // shadcn/ui
-import { Card, CardContent } from '@/components/ui/card'
+
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 


### PR DESCRIPTION
📌 2/2 UI 수정 반영 내역 (페이지별)

1) // src/app/meetings/new/step1-basic/page.tsx
- 모임 생성 초기 화면 레이아웃 여백 정리
- 상단 타이틀 영역과 입력 폼 간 시각적 분리 강화
- 모바일 기준 CTA 버튼 가독성 개선
- 불필요한 Card / Box 스타일 최소화 (플랫 UI 방향)

2) // src/app/meetings/new/step2-meetingmembers/page.tsx
- 하단 [이전] / [다음] 버튼 상단 여백 추가 → 본문 콘텐츠와 버튼 영역 분리
- [참여 멤버 초대] 버튼 컬러를 카카오 브랜드 컬러(--kakao-yellow)로 통일
- 참여자 카드(Card) box-shadow 제거 → 플랫 카드 스타일 적용
- “현재 페이지에는 로그인한 사용자만 표시됨” 안내 문구 추가

3) // src/app/meetings/new/step3-meeting/page.tsx
- “나의 출발지 입력” 텍스트와 [가져오기] 버튼 한 줄(Row) 정렬
- [가져오기] 버튼을 모달 트리거 버튼으로 변경 (rounded-full 적용)
- 모달 오픈 시 전체 화면 배경 오버레이 처리
- 출발지 입력 UX 흐름 정리 (초기 진입 시 혼란 최소화)

4) // src/components/meeting/Step3PlaceList.tsx
- 타이틀을 감싸던 배경 박스(Card / Box) 제거
  (구조는 유지하되 border / background / padding 시각적 제거)
- 지도 영역을 페이지 배경 역할로 재정의
- 지도 위에 참여자 픽 마커 표시
  (기본 마커 내부에 원형 사용자 프로필 이미지 노출)
- 초기 진입 시 각 사용자 출발지 → 중간 지점 흐름이 자연스럽게 보이도록 구조 분리

5) // src/components/meeting/Step4/PlaceList.tsx
   (또는 // src/app/meetings/new/step4-result/page.tsx 구조 기준)
- 결과 페이지 UI 예외 상태(Empty / Loading) 구분 명확화
- Toast / Drawer 등 결과 피드백 UI는 기존 로직 유지
  (노출 타이밍만 UI 관점에서 정리)
- 버튼 및 리스트 영역 중첩 박스 제거 → 정보 위계 단순화
- 결과 확인 → 다음 행동(공유 / 확정)으로 이어지는 CTA 흐름 명확화

[공통 적용 원칙]
- 백엔드 API / 비즈니스 로직 미변경
- 린트 및 빌드 에러가 발생하지 않는 범위 내 UI 수정만 적용
- 접근성 / 구조 개선 사항은 코드 반영 없이 개념 수준으로만 고려
