### PR TITLE
fix: 완료 페이지에서 확정 장소 표시 안되는 문제 수정

### DIFF
--- a/frontend/src/lib/api/place.ts
+++ b/frontend/src/lib/api/place.ts
@@ -15,6 +15,10 @@ export const getCandidatePlaces = (
     params ? { params } : undefined
   )
 
+// 선택된(확정된) 장소 조회
+export const getSelectedPlace = (meetingUuid: string) =>
+  apiClient.get(`/v1/meetings/${meetingUuid}/place`)
+
 export const getCandidateSummary = (
   meetingUuid: string,
   candidateId: number,

--- a/frontend/src/lib/hooks/useMeetingComplete.ts
+++ b/frontend/src/lib/hooks/useMeetingComplete.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
 
 import { getMeetingDetail } from '@/lib/api/meeting'
-import { getCandidatePlaces } from '@/lib/api/place'
+import { getCandidatePlaces, getSelectedPlace } from '@/lib/api/place'
 import type { CommonResponse } from '@/types/api'
 import type { MeetingDetailResponse } from '@/types/meeting'
-import type { PlaceResponse, PlaceCandidate } from '@/types/place'
+import type { PlaceResponse, PlaceCandidate, SelectedPlace } from '@/types/place'
 
 export interface MeetingCompleteViewModel {
   meetingName?: string
@@ -60,7 +60,8 @@ export const useMeetingComplete = (
             ? meetingData?.totalParticipants
             : meetingData?.participants?.length
 
-        let placeData: PlaceCandidate | undefined
+        // 장소 정보 조회: candidateId가 있으면 후보 조회, 없으면 확정된 장소 조회
+        let placeData: PlaceCandidate | SelectedPlace | undefined
         if (isNumber(candidateId)) {
           const placeResponse =
             (await getCandidatePlaces(
@@ -68,6 +69,11 @@ export const useMeetingComplete = (
               candidateId
             )) as CommonResponse<PlaceResponse>
           placeData = placeResponse?.data?.places?.[0]
+        } else {
+          // candidateId가 없으면 확정된 장소 조회
+          const selectedPlaceResponse =
+            (await getSelectedPlace(meetingId)) as CommonResponse<SelectedPlace>
+          placeData = selectedPlaceResponse?.data
         }
 
         const viewModel: MeetingCompleteViewModel = {

--- a/frontend/src/types/place.ts
+++ b/frontend/src/types/place.ts
@@ -13,6 +13,25 @@ export interface PlaceCandidate {
   rating?: number;
 }
 
+// 선택된(확정된) 장소 응답 타입
+export interface SelectedPlace {
+  placeId?: string;
+  placeName?: string;
+  category?: string;
+  categoryGroupCode?: string;
+  categoryGroupName?: string;
+  categoryName?: string;
+  address?: string;
+  roadAddress?: string;
+  latitude?: number;
+  longitude?: number;
+  distance?: number;
+  walkingMinutes?: number;
+  stationName?: string;
+  phone?: string;
+  placeUrl?: string;
+}
+
 export interface PlaceResponse {
   places?: PlaceCandidate[];
   totalCount?: number;


### PR DESCRIPTION


## 변경 사항
<!-- 뭐 했는지 한 줄 설명 -->
- getSelectedPlace API 함수 추가
- SelectedPlace 타입 추가
- useMeetingComplete: candidateId 없으면 확정된 장소 직접 조회

## 관련 이슈
<!-- 사용 예시(closes #123, #124, #125) -->
closes #


## 테스트
- [x] 로컬에서 테스트 완료
- [x] 빌드 확인


<!-- 스크린샷이나 추가 설명 필요하면 여기에 -->
