### PR TITLE
[FE] 참여자 페이지 심플하게 변경 Fe/2yul/epic step2 2

### DIFF
--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -335,8 +335,9 @@ function Step3MembersContent(): JSX.Element {
         />
       </main>
 
-      <div className="mt-10">
-        {/* 1/30[유리] - 하단 버튼 영역 상단 여백 추가 */}
+
+              {/* ===== Step Navigation Fixed (하단 고정) ===== */}
+      <div className="fixed bottom-[var(--bottom-nav-height)] left-0 right-0 z-20 px-4 pb-safe bg-[var(--bg)]">
         <StepNavigation
           prevHref={prevHref}
           nextHref={`/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`}

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -299,7 +299,7 @@ function Step3MembersContent(): JSX.Element {
   // =====================
   return (
     <>
-      <main className="mx-auto max-w-xl space-y-6">
+      <main className="mx-auto max-w-xl space-y-6 border-t border-[var(--border)] pt-3">
         <section>
           <h2 className="text-lg font-semibold">참여자</h2>
           <p className="text-sm text-[var(--text-subtle)]">
@@ -307,6 +307,7 @@ function Step3MembersContent(): JSX.Element {
           </p>
         </section>
 
+        <div className="fixed bottom-[var(--bottom-nav-height2)] left-0 right-0 z-30 px-4 pb-safe bg-[var(--bg)]">
         <Button
           className="w-full gap-2 py-6 rounded-xl bg-[var(--kakao-yellow)] text-black"
           disabled={isReadonly || !isOrganizer}
@@ -322,7 +323,8 @@ function Step3MembersContent(): JSX.Element {
           {/* 1/30[유리] - 카카오 컬러 토큰 적용 */}
           <Send size={18} />
           참여 멤버 초대
-        </Button>
+          </Button>
+          </div>
         {/* 1/30[유리] - 참여자 표시 기준 안내 */}
 
         <MemberList

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -323,18 +323,7 @@ function Step3MembersContent(): JSX.Element {
           <Send size={18} />
           참여 멤버 초대
         </Button>
-
-        <p className="text-xs text-[var(--text-subtle)]">
-          참여자 리스트에는 현재 참여한 사용자만 표시됩니다.
-        </p>
         {/* 1/30[유리] - 참여자 표시 기준 안내 */}
-
-        <Card className="bg-[var(--bg-soft)] shadow-none">
-          {/* 1/30[유리] - 교통편/주소 비노출 및 닉네임 중심 안내 */}
-          <CardContent className="text-sm text-[var(--text-subtle)]">
-            이 단계에서는 닉네임을 기준으로 참여자가 표시됩니다.
-          </CardContent>
-        </Card>
 
         <MemberList
           meetingUuid={meetingUuid}

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -342,7 +342,7 @@ function Step3MembersContent(): JSX.Element {
           }}
           readonly={isReadonly}
         />
-        <div  className="bottom-[var[--bottom-cta-space2)]"/>
+        <div  className="bottom-[var(--bottom-cta-space2)]"/>
       </main>
 
 

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -143,7 +143,7 @@ function Step3MembersContent(): JSX.Element {
   const prevHref = `/meetings/new/step1-basic?meetingUuid=${meetingUuid}${
     readonlyParam ? "&readonly=true" : ""
   }`;
-  const userId = user?.id;
+
 
   // =====================
   // 모임 조회 + 참여자 생성
@@ -155,6 +155,7 @@ function Step3MembersContent(): JSX.Element {
           setIsLoading(false);
           return;
      }
+    const userId = user?.id;
     joinedRef.current = true;
 
     const fetchMeeting = async (): Promise<void> => {
@@ -218,7 +219,7 @@ function Step3MembersContent(): JSX.Element {
     };
 
     void fetchMeeting();
-  }, [meetingUuid, userId]);
+  }, [meetingUuid, user]);
 
   // =====================
   // 예외 케이스 UI
@@ -335,7 +336,7 @@ function Step3MembersContent(): JSX.Element {
 
         <MemberList
           meetingUuid={meetingUuid}
-          userId={userId!}
+          userId={user.id}
           onMyParticipantResolved={(id) => {
             if (!myParticipantId) setMyParticipantId(id);
           }}

--- a/frontend/src/app/meetings/new/step2-members/page.tsx
+++ b/frontend/src/app/meetings/new/step2-members/page.tsx
@@ -299,13 +299,19 @@ function Step3MembersContent(): JSX.Element {
   // =====================
   return (
     <>
-      <main className="mx-auto max-w-xl space-y-6 border-t border-[var(--border)] pt-3">
-        <section>
+      <main className="
+    bg-[var(--bg)]
+    border-t border-[var(--border)]
+    pb-[var(--bottom-cta-space2)]
+  ">    
+
+        <section className="my-3">
           <h2 className="text-lg font-semibold">참여자</h2>
           <p className="text-sm text-[var(--text-subtle)]">
             멤버를 초대하세요.
           </p>
-        </section>
+          </section>
+
 
         <div className="fixed bottom-[var(--bottom-nav-height2)] left-0 right-0 z-30 px-4 pb-safe bg-[var(--bg)]">
         <Button
@@ -335,11 +341,12 @@ function Step3MembersContent(): JSX.Element {
           }}
           readonly={isReadonly}
         />
+        <div  className="bottom-[var[--bottom-cta-space2)]"/>
       </main>
 
 
               {/* ===== Step Navigation Fixed (하단 고정) ===== */}
-      <div className="fixed bottom-[var(--bottom-nav-height)] left-0 right-0 z-20 px-4 pb-safe bg-[var(--bg)]">
+      <div className="app-container fixed bottom-[var(--bottom-nav-height)] left-0 right-0 z-20 px-4 pb-safe bg-[var(--bg)]">
         <StepNavigation
           prevHref={prevHref}
           nextHref={`/meetings/new/step3-meeting?meetingUuid=${meetingUuid}`}

--- a/frontend/src/components/meeting/Step2/MemberStatusList.tsx
+++ b/frontend/src/components/meeting/Step2/MemberStatusList.tsx
@@ -1,10 +1,10 @@
-// src/components/meeting/MemberStatusList.tsx
+// src/components/metting/Step2/MemberStatusList.tsx
 "use client";
 
 import React, { useEffect, useMemo, useState, type ReactNode } from "react";
 import Image from "next/image";
-import { Member } from "../meeting/Step2/Step2MemberList";
-import { TransportMode } from "../meeting/Step2/Step2MemberList";
+import { Member } from "./Step2MemberList";
+import { TransportMode } from "./Step2MemberList";
 
 // shadcn/ui
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/frontend/src/components/meeting/Step2/MemberStatusList.tsx
+++ b/frontend/src/components/meeting/Step2/MemberStatusList.tsx
@@ -1,4 +1,4 @@
-// src/components/metting/Step2/MemberStatusList.tsx
+// src/components/meeting/Step2/MemberStatusList.tsx
 "use client";
 
 import React, { useEffect, useMemo, useState, type ReactNode } from "react";
@@ -26,9 +26,20 @@ interface Props {
 //   PUBLIC: "🚌",
 // };
 
-export default function MemberStatusList({ members, onPersonalChange }: Props) {
-  const myMember = members[0];
-  const otherMembers = useMemo(() => members.slice(1), [members]);
+export default function MemberStatusList({
+  members,
+  currentUserId,
+  onPersonalChange,
+}: Props) {
+  const myMember = useMemo(
+  () => members.find((m) => m.id === currentUserId.toString()),
+  [members, currentUserId]
+);
+
+const otherMembers = useMemo(
+  () => members.filter((m) => m.id !== currentUserId.toString()),
+  [members, currentUserId]
+);
 
   const [myNickname, setMyNickname] = useState("");
 

--- a/frontend/src/components/meeting/Step2/MemberStatusList.tsx
+++ b/frontend/src/components/meeting/Step2/MemberStatusList.tsx
@@ -4,10 +4,10 @@
 import React, { useEffect, useMemo, useState, type ReactNode } from "react";
 import Image from "next/image";
 import { Member } from "./Step2MemberList";
-import { TransportMode } from "./Step2MemberList";
+// import { TransportMode } from "./Step2MemberList";
+import { Input } from "@/components/ui/input";
 
 // shadcn/ui
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -16,15 +16,15 @@ interface Props {
   onPersonalChange: (participantId: number, nickname?: string) => void;
 }
 
-const transportLabelMap: Record<TransportMode, string> = {
-  CAR: "자동차",
-  PUBLIC: "대중교통",
-};
+// const transportLabelMap: Record<TransportMode, string> = {
+//   CAR: "자동차",
+//   PUBLIC: "대중교통",
+// };
 
-const transportIconMap: Record<TransportMode, string> = {
-  CAR: "🚗",
-  PUBLIC: "🚌",
-};
+// const transportIconMap: Record<TransportMode, string> = {
+//   CAR: "🚗",
+//   PUBLIC: "🚌",
+// };
 
 export default function MemberStatusList({ members, onPersonalChange }: Props) {
   const myMember = members[0];
@@ -41,7 +41,7 @@ export default function MemberStatusList({ members, onPersonalChange }: Props) {
   let mySection: ReactNode = null;
   if (myMember) {
     let myAvatar: ReactNode = (
-      <div className="h-10 w-10 rounded-full bg-[var(--neutral-soft)]" />
+      <div className="h-10 w-10 rounded-xl bg-[var(--neutral-soft)]" />
     );
     if (myMember.profileImageUrl) {
       myAvatar = (
@@ -50,57 +50,52 @@ export default function MemberStatusList({ members, onPersonalChange }: Props) {
           alt={myMember.name}
           width={48}
           height={48}
-          className="h-10 w-10 rounded-full object-cover"
+          className="h-10 w-10 rounded-xl object-cover"
         />
       );
     }
 
-    let myTransport: ReactNode = null;
-    if (myMember.originAddress && myMember.transport) {
-      myTransport = (
-        <div className="mt-1 flex items-center gap-2">
-          <div className="flex items-center gap-1 rounded-full bg-[var(--neutral-soft)] px-3 py-1 text-xs font-semibold text-[var(--text)]">
-            {transportIconMap[myMember.transport as TransportMode]}{" "}
-            {transportLabelMap[myMember.transport as TransportMode]}
-          </div>
-          <div className="text-xs text-[var(--text-subtle)]">
-            {myMember.originAddress}
-          </div>
-        </div>
-      );
-    }
+    //
+    // let myTransport: ReactNode = null;
+    // if (myMember.originAddress && myMember.transport) {
+    //   myTransport = (
+    //     <div className="mt-1 flex items-center gap-2">
+    //       <div className="flex items-center gap-1 rounded-full bg-[var(--neutral-soft)] px-3 py-1 text-xs font-semibold text-[var(--text)]">
+    //         {transportIconMap[myMember.transport as TransportMode]}{" "}
+    //         {transportLabelMap[myMember.transport as TransportMode]}
+    //       </div>
+    //       <div className="text-xs text-[var(--text-subtle)]">
+    //         {myMember.originAddress}
+    //       </div>
+    //     </div>
+    //   );
+    // }
 
     mySection = (
-      <Card className="border border-[var(--border)] bg-[var(--bg-soft)]">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base text-[var(--text)]">
-            내 정보
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
+      <div className="border-y border-[var(--border)] bg-[var(--bg-soft)] py-3">
           <div className="flex items-center gap-3">
             {myAvatar}
             <div className="flex-1">
               <p className="text-sm font-semibold text-[var(--text)]">
                 {myMember.name}
               </p>
-              {myTransport}
+              {/* {myTransport} */}
             </div>
           </div>
 
           <div className="flex items-center gap-2 text-xs">
-            <span className="text-[var(--text-subtle)]">닉네임 설정 :</span>
-            <input
-              type="text"
-              placeholder="미입력 시 이름으로 표시"
-              value={myNickname}
-              onChange={(e) => setMyNickname(e.target.value)}
-              className="flex-1 rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 py-1 text-[var(--text)] outline-none"
-            />
+            <span className="text-[var(--text-subtle)]">닉네임</span>
+            <Input
+            type="text"
+            placeholder="필요시 닉네임을 입력하세요"
+            value={myNickname}
+            onChange={(e) => setMyNickname(e.target.value)}
+            className="h-10 flex-1 rounded-xl"
+          />
             <Button
               type="button"
               variant="outline"
-              className="border-[var(--border)] bg-[var(--bg)] text-[var(--text)]"
+              className="border-[var(--border)] rounded-xl py-5 bg-[var(--primary)] text-[var(--primary-soft)]"
               onClick={() =>
                 onPersonalChange(myMember.participantId, myNickname)
               }
@@ -108,21 +103,15 @@ export default function MemberStatusList({ members, onPersonalChange }: Props) {
               저장
             </Button>
           </div>
-        </CardContent>
-      </Card>
+      </div>
     );
   }
 
   let othersSection: ReactNode = null;
   if (otherMembers.length > 0) {
     othersSection = (
-      <Card className="border border-[var(--border)] bg-[var(--bg-soft)]">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base text-[var(--text)]">
-            다른 참여자
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-2">
+      <div className="">
+        <div className="grid gap-0 grid-cols-1 md:grid-cols-2 lg:grid-cols-2">
           {otherMembers.map((member) => {
             let memberAvatar: ReactNode = (
               <div className="h-10 w-10 rounded-full bg-[var(--neutral-soft)]" />
@@ -139,20 +128,20 @@ export default function MemberStatusList({ members, onPersonalChange }: Props) {
               );
             }
 
-            let memberTransport: ReactNode = null;
-            if (member.originAddress && member.transport) {
-              memberTransport = (
-                <div className="mt-1 flex items-center gap-2">
-                  <div className="flex items-center gap-1 rounded-full bg-[var(--neutral-soft)] px-3 py-1 text-xs font-semibold text-[var(--text)]">
-                    {transportIconMap[member.transport as TransportMode]}{" "}
-                    {transportLabelMap[member.transport as TransportMode]}
-                  </div>
-                  <div className="text-xs text-[var(--text-subtle)]">
-                    {member.originAddress}
-                  </div>
-                </div>
-              );
-            }
+            // let memberTransport: ReactNode = null;
+            // if (member.originAddress && member.transport) {
+            //   memberTransport = (
+            //     <div className="mt-1 flex items-center gap-2">
+            //       <div className="flex items-center gap-1 rounded-full bg-[var(--neutral-soft)] px-3 py-1 text-xs font-semibold text-[var(--text)]">
+            //         {/* {transportIconMap[member.transport as TransportMode]}{" "}
+            //         {transportLabelMap[member.transport as TransportMode]} */}
+            //       </div>
+            //       <div className="text-xs text-[var(--text-subtle)]">
+            //         {member.originAddress}
+            //       </div>
+            //     </div>
+            //   );
+            // }
 
             let nicknameLine: ReactNode = null;
             if (member.nickname) {
@@ -174,15 +163,15 @@ export default function MemberStatusList({ members, onPersonalChange }: Props) {
                     <p className="text-sm font-semibold text-[var(--text)]">
                       {member.name}
                     </p>
-                    {memberTransport}
+                    {/* {memberTransport} */}
                   </div>
                 </div>
                 {nicknameLine}
               </div>
             );
           })}
-        </CardContent>
-      </Card>
+       </div>
+      </div>
     );
   }
 

--- a/frontend/src/components/meeting/Step2/MemberSummaryGrid.tsx
+++ b/frontend/src/components/meeting/Step2/MemberSummaryGrid.tsx
@@ -1,4 +1,4 @@
-// src/components/metting/Step2/MemberSummaryGrid.tsx
+// src/components/meeting/Step2/MemberSummaryGrid.tsx
 import StepCard from "@/components/meeting/StepCard";
 import { Member } from "./Step2MemberList";
 

--- a/frontend/src/components/meeting/Step2/MemberSummaryGrid.tsx
+++ b/frontend/src/components/meeting/Step2/MemberSummaryGrid.tsx
@@ -1,6 +1,6 @@
-// src/components/member/MemberSummaryGrid.tsx
+// src/components/metting/Step2/MemberSummaryGrid.tsx
 import StepCard from "@/components/meeting/StepCard";
-import { Member } from "../meeting/Step2/Step2MemberList";
+import { Member } from "./Step2MemberList";
 
 // shadcn/ui
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";

--- a/frontend/src/components/meeting/Step2/Step2Address.tsx
+++ b/frontend/src/components/meeting/Step2/Step2Address.tsx
@@ -1,4 +1,4 @@
-// src/components/map/Step2Address.tsx
+// src/components/meeting/Step2/Step2Address.tsx
 "use client";
 
 import { useState } from "react";

--- a/frontend/src/components/meeting/Step2/Step2MemberList.tsx
+++ b/frontend/src/components/meeting/Step2/Step2MemberList.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
-import MemberStatusList from "@/components/member/MemberStatusList";
+import MemberStatusList from "@/components/meeting/Step2/MemberStatusList";
 
 interface MemberListProps {
   meetingUuid: string;

--- a/frontend/src/components/meeting/Step2/Step2MemberList.tsx
+++ b/frontend/src/components/meeting/Step2/Step2MemberList.tsx
@@ -1,4 +1,4 @@
-// src/components/meeting/Step3/MemberList.tsx
+// src/components/meeting/Step2/MemberList.tsx
 "use client";
 
 import { useEffect, useMemo, useState } from "react";

--- a/frontend/src/components/member/MemberStatusList.tsx
+++ b/frontend/src/components/member/MemberStatusList.tsx
@@ -188,16 +188,7 @@ export default function MemberStatusList({ members, onPersonalChange }: Props) {
 
   return (
     <div className="space-y-4">
-      <Card className="border border-[var(--border)] bg-[var(--bg-soft)]">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base text-[var(--text)]">
-            참여자 리스트
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm text-[var(--text-subtle)]">
-          참여자 정보와 교통수단을 확인할 수 있습니다.
-        </CardContent>
-      </Card>
+      
 
       {mySection}
       {othersSection}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -40,9 +40,13 @@
 
   /* ===== Layout ===== */
   --bottom-cta-height: calc(0px + env(safe-area-inset-bottom));
+
   --bottom-nav-height: calc(80px + env(safe-area-inset-bottom));
-  --bottom-nav-height2: calc(140px + env(safe-area-inset-bottom));
   --bottom-cta-space: 150px; /* CTA 높이 + 여유 */
+
+  --bottom-nav-height2: calc(140px + env(safe-area-inset-bottom));
+  --bottom-cta-space2: 210px; /* CTA 높이 + 여유 */
+
 
   /* ===== Font ===== */
   --font-sans: "Space Grotesk", "IBM Plex Sans", ui-sans-serif, system-ui;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -41,6 +41,7 @@
   /* ===== Layout ===== */
   --bottom-cta-height: calc(0px + env(safe-area-inset-bottom));
   --bottom-nav-height: calc(80px + env(safe-area-inset-bottom));
+  --bottom-nav-height2: calc(140px + env(safe-area-inset-bottom));
   --bottom-cta-space: 150px; /* CTA 높이 + 여유 */
 
   /* ===== Font ===== */


### PR DESCRIPTION
## 변경 사항
<!-- 뭐 했는지 한 줄 설명 -->
복잡한 ui 심플 하게 변경 
(교통정보, 주소 노출은 다음 스탭에서 각자 선택이라 현 스탭에서는 노출 안함) 
초대자 버튼 하단 고정 
[이전][다음] 버튼 하단 고정 

## 관련 이슈
<!-- 사용 예시(closes #123, #124, #125) -->
closes #


## 테스트
- [x] 로컬에서 테스트 완료
- [x] 빌드 확인


<!-- 스크린샷이나 추가 설명 필요하면 여기에 -->
