### PR TITLE
fix: WALK 참여자 이동시간 조회 시 500 에러 수정

### DIFF
--- a/backend/src/main/java/com/magicdev/manalgak/domain/route/service/RouteService.java
+++ b/backend/src/main/java/com/magicdev/manalgak/domain/route/service/RouteService.java
@@ -142,13 +142,16 @@ public class RouteService {
                         && p.getOrigin().getLongitude() != null)
                 .toList();
 
-        Map<Boolean, List<Participant>> partitioned = validParticipants.stream()
-                .collect(Collectors.partitioningBy(
-                        p -> p.getType() == Participant.TransportType.CAR
-                ));
+        List<Participant> publicParticipants = validParticipants.stream()
+                .filter(p -> p.getType() == Participant.TransportType.PUBLIC
+                        || p.getType() == null)
+                .toList();
 
-        List<Participant> publicParticipants = partitioned.get(false);
-        List<Participant> carParticipants = partitioned.get(true);
+        List<Participant> carParticipants = validParticipants.stream()
+                .filter(p -> p.getType() == Participant.TransportType.CAR)
+                .toList();
+
+        // WALK 참여자는 프론트엔드에서 walkingMinutes로 별도 처리 (ODsay/Kakao API 호출 불필요)
 
         List<RouteResponse.RouteInfo> publicRoutes = List.of();
         if (!publicParticipants.isEmpty()) {


### PR DESCRIPTION

## 변경 사항
<!-- 뭐 했는지 한 줄 설명 -->
WALK 타입 참여자가 ODsay 대중교통 API로 잘못 전달되어
경로 조회 실패 시 전체 요청이 500 에러로 이어지던 문제 수정

- CAR vs 나머지 이분법 분류를 PUBLIC/CAR/WALK 명시적 분리로 변경
- WALK 참여자는 외부 API 호출에서 제외 (프론트엔드에서 walkingMinutes로 처리)


## 관련 이슈
<!-- 사용 예시(closes #123, #124, #125) -->
closes #


## 테스트
- [ ] 로컬에서 테스트 완료
- [ ] 빌드 확인


<!-- 스크린샷이나 추가 설명 필요하면 여기에 -->
